### PR TITLE
Build Rust 1.43.0 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL maintainer="Kit Ewbank <Kit_Ewbank@hotmail.com>"
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.41.1
+    RUST_VERSION=1.43.0
 
 RUN yum install -y gcc gcc-c++ openssl-devel;\
     curl https://sh.rustup.rs -sSf | sh -s -- --no-modify-path --profile minimal --default-toolchain $RUST_VERSION -y; \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-LOCAL=rust:1.41.1-amazonlinux2018.03.0.20191219.0
-REMOTE=ewbankkit/rust-amazonlinux:1.41.1-2018.03.0.20191219.0
+LOCAL=rust:1.43.0-amazonlinux2018.03.0.20191219.0
+REMOTE=ewbankkit/rust-amazonlinux:1.43.0-2018.03.0.20191219.0
 
 .PHONY: all image push
 


### PR DESCRIPTION
Closes https://github.com/ewbankkit/rust-amazonlinux/issues/2.

```console
$ make image
docker build --file Dockerfile --tag rust:1.43.0-amazonlinux2018.03.0.20191219.0 .
Sending build context to Docker daemon  86.02kB
Step 1/5 : FROM amazonlinux:2018.03.0.20191219.0
 ---> 5f555533483a
Step 2/5 : LABEL maintainer="Kit Ewbank <Kit_Ewbank@hotmail.com>"
 ---> Using cache
 ---> 5deb344ad1fc
Step 3/5 : ENV RUSTUP_HOME=/usr/local/rustup     CARGO_HOME=/usr/local/cargo     PATH=/usr/local/cargo/bin:$PATH     RUST_VERSION=1.43.0
 ---> Running in db8065dd9086
Removing intermediate container db8065dd9086
 ---> 83a8d2f37cff
Step 4/5 : RUN yum install -y gcc gcc-c++ openssl-devel;    curl https://sh.rustup.rs -sSf | sh -s -- --no-modify-path --profile minimal --default-toolchain $RUST_VERSION -y;     chmod -R a+w $RUSTUP_HOME $CARGO_HOME;     rustup --version;     cargo --version;     rustc --version;
 ---> Running in 06ff2863b73f
Loaded plugins: ovl, priorities
Resolving Dependencies
--> Running transaction check
---> Package gcc.noarch 0:4.8.5-1.22.amzn1 will be installed
--> Processing Dependency: gcc48 >= 4.8.5 for package: gcc-4.8.5-1.22.amzn1.noarch
---> Package gcc-c++.noarch 0:4.8.5-1.22.amzn1 will be installed
--> Processing Dependency: gcc48-c++ >= 4.8.5 for package: gcc-c++-4.8.5-1.22.amzn1.noarch
--> Processing Dependency: libstdc++48 >= 4.8.5 for package: gcc-c++-4.8.5-1.22.amzn1.noarch
---> Package openssl-devel.x86_64 1:1.0.2k-16.151.amzn1 will be installed
--> Processing Dependency: openssl(x86-64) = 1:1.0.2k-16.151.amzn1 for package: 1:openssl-devel-1.0.2k-16.151.amzn1.x86_64
--> Processing Dependency: zlib-devel(x86-64) for package: 1:openssl-devel-1.0.2k-16.151.amzn1.x86_64
--> Processing Dependency: krb5-devel(x86-64) for package: 1:openssl-devel-1.0.2k-16.151.amzn1.x86_64
--> Running transaction check
---> Package gcc48.x86_64 0:4.8.5-28.142.amzn1 will be installed
--> Processing Dependency: libgcc48(x86-64) = 4.8.5 for package: gcc48-4.8.5-28.142.amzn1.x86_64
--> Processing Dependency: cpp48(x86-64) = 4.8.5-28.142.amzn1 for package: gcc48-4.8.5-28.142.amzn1.x86_64
--> Processing Dependency: libgomp(x86-64) >= 4.8.5-28.142.amzn1 for package: gcc48-4.8.5-28.142.amzn1.x86_64
--> Processing Dependency: glibc-devel(x86-64) >= 2.2.90-12 for package: gcc48-4.8.5-28.142.amzn1.x86_64
--> Processing Dependency: binutils >= 2.20.51.0.2-12 for package: gcc48-4.8.5-28.142.amzn1.x86_64
--> Processing Dependency: libmpfr.so.4()(64bit) for package: gcc48-4.8.5-28.142.amzn1.x86_64
--> Processing Dependency: libmpc.so.3()(64bit) for package: gcc48-4.8.5-28.142.amzn1.x86_64
--> Processing Dependency: libgomp.so.1()(64bit) for package: gcc48-4.8.5-28.142.amzn1.x86_64
---> Package gcc48-c++.x86_64 0:4.8.5-28.142.amzn1 will be installed
---> Package krb5-devel.x86_64 0:1.15.1-34.44.amzn1 will be installed
--> Processing Dependency: libkadm5(x86-64) = 1.15.1-34.44.amzn1 for package: krb5-devel-1.15.1-34.44.amzn1.x86_64
--> Processing Dependency: libverto-devel for package: krb5-devel-1.15.1-34.44.amzn1.x86_64
--> Processing Dependency: libselinux-devel for package: krb5-devel-1.15.1-34.44.amzn1.x86_64
--> Processing Dependency: libcom_err-devel for package: krb5-devel-1.15.1-34.44.amzn1.x86_64
--> Processing Dependency: keyutils-libs-devel for package: krb5-devel-1.15.1-34.44.amzn1.x86_64
---> Package libstdc++48.x86_64 0:4.8.5-28.142.amzn1 will be installed
---> Package openssl.x86_64 1:1.0.2k-16.150.amzn1 will be updated
---> Package openssl.x86_64 1:1.0.2k-16.151.amzn1 will be an update
---> Package zlib-devel.x86_64 0:1.2.8-7.18.amzn1 will be installed
--> Running transaction check
---> Package binutils.x86_64 0:2.25.1-31.base.66.amzn1 will be installed
---> Package cpp48.x86_64 0:4.8.5-28.142.amzn1 will be installed
---> Package glibc-devel.x86_64 0:2.17-292.180.amzn1 will be installed
--> Processing Dependency: glibc-headers = 2.17-292.180.amzn1 for package: glibc-devel-2.17-292.180.amzn1.x86_64
--> Processing Dependency: glibc(x86-64) = 2.17-292.180.amzn1 for package: glibc-devel-2.17-292.180.amzn1.x86_64
--> Processing Dependency: glibc-headers for package: glibc-devel-2.17-292.180.amzn1.x86_64
---> Package keyutils-libs-devel.x86_64 0:1.5.8-3.12.amzn1 will be installed
---> Package libcom_err-devel.x86_64 0:1.43.5-2.43.amzn1 will be installed
---> Package libgcc48.x86_64 0:4.8.5-28.142.amzn1 will be installed
---> Package libgomp.x86_64 0:6.4.1-1.45.amzn1 will be installed
---> Package libkadm5.x86_64 0:1.15.1-34.44.amzn1 will be installed
---> Package libmpc.x86_64 0:1.0.1-3.3.amzn1 will be installed
---> Package libselinux-devel.x86_64 0:2.1.10-3.22.amzn1 will be installed
--> Processing Dependency: libsepol-devel >= 2.1.5-1 for package: libselinux-devel-2.1.10-3.22.amzn1.x86_64
--> Processing Dependency: pkgconfig(libsepol) for package: libselinux-devel-2.1.10-3.22.amzn1.x86_64
---> Package libverto-devel.x86_64 0:0.2.5-4.9.amzn1 will be installed
---> Package mpfr.x86_64 0:3.1.1-4.14.amzn1 will be installed
--> Running transaction check
---> Package glibc.x86_64 0:2.17-292.178.amzn1 will be updated
--> Processing Dependency: glibc(x86-64) = 2.17-292.178.amzn1 for package: glibc-common-2.17-292.178.amzn1.x86_64
---> Package glibc.x86_64 0:2.17-292.180.amzn1 will be an update
---> Package glibc-headers.x86_64 0:2.17-292.180.amzn1 will be installed
--> Processing Dependency: kernel-headers >= 2.2.1 for package: glibc-headers-2.17-292.180.amzn1.x86_64
--> Processing Dependency: kernel-headers for package: glibc-headers-2.17-292.180.amzn1.x86_64
---> Package libsepol-devel.x86_64 0:2.1.7-3.12.amzn1 will be installed
--> Running transaction check
---> Package glibc-common.x86_64 0:2.17-292.178.amzn1 will be updated
---> Package glibc-common.x86_64 0:2.17-292.180.amzn1 will be an update
---> Package kernel-headers.x86_64 0:4.14.173-106.229.amzn1 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

================================================================================
 Package               Arch     Version                    Repository      Size
================================================================================
Installing:
 gcc                   noarch   4.8.5-1.22.amzn1           amzn-main      4.1 k
 gcc-c++               noarch   4.8.5-1.22.amzn1           amzn-main      4.0 k
 openssl-devel         x86_64   1:1.0.2k-16.151.amzn1      amzn-updates   1.7 M
Installing for dependencies:
 binutils              x86_64   2.25.1-31.base.66.amzn1    amzn-main      7.2 M
 cpp48                 x86_64   4.8.5-28.142.amzn1         amzn-updates   6.7 M
 gcc48                 x86_64   4.8.5-28.142.amzn1         amzn-updates    18 M
 gcc48-c++             x86_64   4.8.5-28.142.amzn1         amzn-updates   9.8 M
 glibc-devel           x86_64   2.17-292.180.amzn1         amzn-updates   1.2 M
 glibc-headers         x86_64   2.17-292.180.amzn1         amzn-updates   763 k
 kernel-headers        x86_64   4.14.173-106.229.amzn1     amzn-updates   1.2 M
 keyutils-libs-devel   x86_64   1.5.8-3.12.amzn1           amzn-main       37 k
 krb5-devel            x86_64   1.15.1-34.44.amzn1         amzn-updates   292 k
 libcom_err-devel      x86_64   1.43.5-2.43.amzn1          amzn-updates    36 k
 libgcc48              x86_64   4.8.5-28.142.amzn1         amzn-updates   155 k
 libgomp               x86_64   6.4.1-1.45.amzn1           amzn-main      204 k
 libkadm5              x86_64   1.15.1-34.44.amzn1         amzn-updates   201 k
 libmpc                x86_64   1.0.1-3.3.amzn1            amzn-main       53 k
 libselinux-devel      x86_64   2.1.10-3.22.amzn1          amzn-main      157 k
 libsepol-devel        x86_64   2.1.7-3.12.amzn1           amzn-main       70 k
 libstdc++48           x86_64   4.8.5-28.142.amzn1         amzn-updates   408 k
 libverto-devel        x86_64   0.2.5-4.9.amzn1            amzn-main       11 k
 mpfr                  x86_64   3.1.1-4.14.amzn1           amzn-main      237 k
 zlib-devel            x86_64   1.2.8-7.18.amzn1           amzn-main       53 k
Updating for dependencies:
 glibc                 x86_64   2.17-292.180.amzn1         amzn-updates   5.8 M
 glibc-common          x86_64   2.17-292.180.amzn1         amzn-updates    28 M
 openssl               x86_64   1:1.0.2k-16.151.amzn1      amzn-updates   1.8 M

Transaction Summary
================================================================================
Install  3 Packages (+20 Dependent packages)
Upgrade             (  3 Dependent packages)

Total download size: 84 M
Downloading packages:
--------------------------------------------------------------------------------
Total                                              6.3 MB/s |  84 MB  00:13     
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Installing : libgcc48-4.8.5-28.142.amzn1.x86_64                          1/29 
  Updating   : glibc-common-2.17-292.180.amzn1.x86_64                      2/29 
  Updating   : glibc-2.17-292.180.amzn1.x86_64                             3/29 
  Installing : mpfr-3.1.1-4.14.amzn1.x86_64                                4/29 
  Installing : libmpc-1.0.1-3.3.amzn1.x86_64                               5/29 
  Updating   : 1:openssl-1.0.2k-16.151.amzn1.x86_64                        6/29 
  Installing : libstdc++48-4.8.5-28.142.amzn1.x86_64                       7/29 
  Installing : libkadm5-1.15.1-34.44.amzn1.x86_64                          8/29 
  Installing : cpp48-4.8.5-28.142.amzn1.x86_64                             9/29 
  Installing : libgomp-6.4.1-1.45.amzn1.x86_64                            10/29 
  Installing : binutils-2.25.1-31.base.66.amzn1.x86_64                    11/29 
  Installing : libcom_err-devel-1.43.5-2.43.amzn1.x86_64                  12/29 
  Installing : libverto-devel-0.2.5-4.9.amzn1.x86_64                      13/29 
  Installing : libsepol-devel-2.1.7-3.12.amzn1.x86_64                     14/29 
  Installing : libselinux-devel-2.1.10-3.22.amzn1.x86_64                  15/29 
  Installing : kernel-headers-4.14.173-106.229.amzn1.x86_64               16/29 
  Installing : glibc-headers-2.17-292.180.amzn1.x86_64                    17/29 
  Installing : glibc-devel-2.17-292.180.amzn1.x86_64                      18/29 
  Installing : gcc48-4.8.5-28.142.amzn1.x86_64                            19/29 
  Installing : gcc-4.8.5-1.22.amzn1.noarch                                20/29 
  Installing : gcc48-c++-4.8.5-28.142.amzn1.x86_64                        21/29 
  Installing : zlib-devel-1.2.8-7.18.amzn1.x86_64                         22/29 
  Installing : keyutils-libs-devel-1.5.8-3.12.amzn1.x86_64                23/29 
  Installing : krb5-devel-1.15.1-34.44.amzn1.x86_64                       24/29 
  Installing : 1:openssl-devel-1.0.2k-16.151.amzn1.x86_64                 25/29 
  Installing : gcc-c++-4.8.5-1.22.amzn1.noarch                            26/29 
  Cleanup    : 1:openssl-1.0.2k-16.150.amzn1.x86_64                       27/29 
  Cleanup    : glibc-2.17-292.178.amzn1.x86_64                            28/29 
  Cleanup    : glibc-common-2.17-292.178.amzn1.x86_64                     29/29 
  Verifying  : glibc-common-2.17-292.180.amzn1.x86_64                      1/29 
  Verifying  : gcc-4.8.5-1.22.amzn1.noarch                                 2/29 
  Verifying  : libstdc++48-4.8.5-28.142.amzn1.x86_64                       3/29 
  Verifying  : glibc-2.17-292.180.amzn1.x86_64                             4/29 
  Verifying  : gcc-c++-4.8.5-1.22.amzn1.noarch                             5/29 
  Verifying  : glibc-devel-2.17-292.180.amzn1.x86_64                       6/29 
  Verifying  : mpfr-3.1.1-4.14.amzn1.x86_64                                7/29 
  Verifying  : libselinux-devel-2.1.10-3.22.amzn1.x86_64                   8/29 
  Verifying  : libkadm5-1.15.1-34.44.amzn1.x86_64                          9/29 
  Verifying  : keyutils-libs-devel-1.5.8-3.12.amzn1.x86_64                10/29 
  Verifying  : zlib-devel-1.2.8-7.18.amzn1.x86_64                         11/29 
  Verifying  : cpp48-4.8.5-28.142.amzn1.x86_64                            12/29 
  Verifying  : glibc-headers-2.17-292.180.amzn1.x86_64                    13/29 
  Verifying  : gcc48-4.8.5-28.142.amzn1.x86_64                            14/29 
  Verifying  : kernel-headers-4.14.173-106.229.amzn1.x86_64               15/29 
  Verifying  : krb5-devel-1.15.1-34.44.amzn1.x86_64                       16/29 
  Verifying  : 1:openssl-1.0.2k-16.151.amzn1.x86_64                       17/29 
  Verifying  : gcc48-c++-4.8.5-28.142.amzn1.x86_64                        18/29 
  Verifying  : libmpc-1.0.1-3.3.amzn1.x86_64                              19/29 
  Verifying  : 1:openssl-devel-1.0.2k-16.151.amzn1.x86_64                 20/29 
  Verifying  : libgomp-6.4.1-1.45.amzn1.x86_64                            21/29 
  Verifying  : libsepol-devel-2.1.7-3.12.amzn1.x86_64                     22/29 
  Verifying  : libverto-devel-0.2.5-4.9.amzn1.x86_64                      23/29 
  Verifying  : libcom_err-devel-1.43.5-2.43.amzn1.x86_64                  24/29 
  Verifying  : binutils-2.25.1-31.base.66.amzn1.x86_64                    25/29 
  Verifying  : libgcc48-4.8.5-28.142.amzn1.x86_64                         26/29 
  Verifying  : glibc-2.17-292.178.amzn1.x86_64                            27/29 
  Verifying  : glibc-common-2.17-292.178.amzn1.x86_64                     28/29 
  Verifying  : 1:openssl-1.0.2k-16.150.amzn1.x86_64                       29/29 

Installed:
  gcc.noarch 0:4.8.5-1.22.amzn1               gcc-c++.noarch 0:4.8.5-1.22.amzn1 
  openssl-devel.x86_64 1:1.0.2k-16.151.amzn1 

Dependency Installed:
  binutils.x86_64 0:2.25.1-31.base.66.amzn1                                     
  cpp48.x86_64 0:4.8.5-28.142.amzn1                                             
  gcc48.x86_64 0:4.8.5-28.142.amzn1                                             
  gcc48-c++.x86_64 0:4.8.5-28.142.amzn1                                         
  glibc-devel.x86_64 0:2.17-292.180.amzn1                                       
  glibc-headers.x86_64 0:2.17-292.180.amzn1                                     
  kernel-headers.x86_64 0:4.14.173-106.229.amzn1                                
  keyutils-libs-devel.x86_64 0:1.5.8-3.12.amzn1                                 
  krb5-devel.x86_64 0:1.15.1-34.44.amzn1                                        
  libcom_err-devel.x86_64 0:1.43.5-2.43.amzn1                                   
  libgcc48.x86_64 0:4.8.5-28.142.amzn1                                          
  libgomp.x86_64 0:6.4.1-1.45.amzn1                                             
  libkadm5.x86_64 0:1.15.1-34.44.amzn1                                          
  libmpc.x86_64 0:1.0.1-3.3.amzn1                                               
  libselinux-devel.x86_64 0:2.1.10-3.22.amzn1                                   
  libsepol-devel.x86_64 0:2.1.7-3.12.amzn1                                      
  libstdc++48.x86_64 0:4.8.5-28.142.amzn1                                       
  libverto-devel.x86_64 0:0.2.5-4.9.amzn1                                       
  mpfr.x86_64 0:3.1.1-4.14.amzn1                                                
  zlib-devel.x86_64 0:1.2.8-7.18.amzn1                                          

Dependency Updated:
  glibc.x86_64 0:2.17-292.180.amzn1    glibc-common.x86_64 0:2.17-292.180.amzn1
  openssl.x86_64 1:1.0.2k-16.151.amzn1

Complete!
info: downloading installer
info: profile set to 'minimal'
info: default host triple is x86_64-unknown-linux-gnu
info: syncing channel updates for '1.43.0-x86_64-unknown-linux-gnu'
info: latest update on 2020-04-23, rust version 1.43.0 (4fb7144ed 2020-04-20)
info: downloading component 'cargo'
info: downloading component 'rust-std'
info: downloading component 'rustc'
info: installing component 'cargo'
info: installing component 'rust-std'
info: installing component 'rustc'

info: default toolchain set to '1.43.0'
  1.43.0 installed - rustc 1.43.0 (4fb7144ed 2020-04-20)


Rust is installed now. Great!

To get started you need Cargo's bin directory (/usr/local/cargo/bin) in your 
PATH
environment variable.

To configure your current shell run source /usr/local/cargo/env
rustup 1.21.1 (7832b2ebe 2019-12-20)
cargo 1.43.0 (3532cf738 2020-03-17)
rustc 1.43.0 (4fb7144ed 2020-04-20)
Removing intermediate container 06ff2863b73f
 ---> ef4102b6e1b4
Step 5/5 : WORKDIR /volume
 ---> Running in f0f3c673c666
Removing intermediate container f0f3c673c666
 ---> 7e8aa6b9079d
Successfully built 7e8aa6b9079d
Successfully tagged rust:1.43.0-amazonlinux2018.03.0.20191219.0
docker tag rust:1.43.0-amazonlinux2018.03.0.20191219.0 ewbankkit/rust-amazonlinux:1.43.0-2018.03.0.20191219.0
$ make push
docker build --file Dockerfile --tag rust:1.43.0-amazonlinux2018.03.0.20191219.0 .
Sending build context to Docker daemon  86.02kB
Step 1/5 : FROM amazonlinux:2018.03.0.20191219.0
 ---> 5f555533483a
Step 2/5 : LABEL maintainer="Kit Ewbank <Kit_Ewbank@hotmail.com>"
 ---> Using cache
 ---> 5deb344ad1fc
Step 3/5 : ENV RUSTUP_HOME=/usr/local/rustup     CARGO_HOME=/usr/local/cargo     PATH=/usr/local/cargo/bin:$PATH     RUST_VERSION=1.43.0
 ---> Using cache
 ---> 83a8d2f37cff
Step 4/5 : RUN yum install -y gcc gcc-c++ openssl-devel;    curl https://sh.rustup.rs -sSf | sh -s -- --no-modify-path --profile minimal --default-toolchain $RUST_VERSION -y;     chmod -R a+w $RUSTUP_HOME $CARGO_HOME;     rustup --version;     cargo --version;     rustc --version;
 ---> Using cache
 ---> ef4102b6e1b4
Step 5/5 : WORKDIR /volume
 ---> Using cache
 ---> 7e8aa6b9079d
Successfully built 7e8aa6b9079d
Successfully tagged rust:1.43.0-amazonlinux2018.03.0.20191219.0
docker tag rust:1.43.0-amazonlinux2018.03.0.20191219.0 ewbankkit/rust-amazonlinux:1.43.0-2018.03.0.20191219.0
docker push ewbankkit/rust-amazonlinux:1.43.0-2018.03.0.20191219.0
The push refers to repository [docker.io/ewbankkit/rust-amazonlinux]
4f996f14f933: Pushed 
155c0386847e: Pushed 
caeeb4299004: Layer already exists 
1.43.0-2018.03.0.20191219.0: digest: sha256:b5b42c933e26d62d9f7f8164228d026f56507671bf62324094bf520a2d6658c3 size: 949
```