### PR TITLE
Build Rust 1.45.0 image on amazonlinux:2018.03.0.20200602.1 base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # Build image for building with Rust on Amazon Linux, suitable for custom AWS Lambda runtimes.
 
-FROM amazonlinux:2018.03.0.20191219.0
+FROM amazonlinux:2018.03.0.20200602.1
 LABEL maintainer="Kit Ewbank <Kit_Ewbank@hotmail.com>"
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.43.0
+    RUST_VERSION=1.45.0
 
 RUN yum install -y gcc gcc-c++ openssl-devel;\
     curl https://sh.rustup.rs -sSf | sh -s -- --no-modify-path --profile minimal --default-toolchain $RUST_VERSION -y; \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-LOCAL=rust:1.43.0-amazonlinux2018.03.0.20191219.0
-REMOTE=ewbankkit/rust-amazonlinux:1.43.0-2018.03.0.20191219.0
+LOCAL=rust:1.45.0-amazonlinux2018.03.0.20200602.1
+REMOTE=ewbankkit/rust-amazonlinux:1.45.0-2018.03.0.20200602.1
 
 .PHONY: all image push
 


### PR DESCRIPTION
Closes https://github.com/ewbankkit/rust-amazonlinux/issues/4.