### PR TITLE
Build Rust 1.48.0 images

### DIFF
--- a/Dockerfile.al
+++ b/Dockerfile.al
@@ -6,7 +6,7 @@ LABEL maintainer="Kit Ewbank <Kit_Ewbank@hotmail.com>"
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.45.0
+    RUST_VERSION=1.48.0
 
 RUN yum install -y gcc gcc-c++ openssl-devel; \
     curl https://sh.rustup.rs -sSf | sh -s -- --no-modify-path --profile minimal --default-toolchain $RUST_VERSION -y; \

--- a/Dockerfile.al2
+++ b/Dockerfile.al2
@@ -6,7 +6,7 @@ LABEL maintainer="Kit Ewbank <Kit_Ewbank@hotmail.com>"
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.45.2
+    RUST_VERSION=1.48.0
 
 RUN yum install -y gcc gcc-c++ openssl-devel; \
     curl https://sh.rustup.rs -sSf | sh -s -- --no-modify-path --profile minimal --default-toolchain $RUST_VERSION -y; \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-LOCAL_AL=rust:1.45.0-amazonlinux2018.03.0.20200602.1
-REMOTE_AL=ewbankkit/rust-amazonlinux:1.45.0-2018.03.0.20200602.1
-LOCAL_AL2=rust:1.45.2-amazonlinux2.0.20200722.0
-REMOTE_AL2=ewbankkit/rust-amazonlinux:1.45.2-2.0.20200722.0
+LOCAL_AL=rust:1.48.0-amazonlinux2018.03.0.20200602.1
+REMOTE_AL=ewbankkit/rust-amazonlinux:1.48.0-2018.03.0.20200602.1
+LOCAL_AL2=rust:1.48.0-amazonlinux2.0.20200722.0
+REMOTE_AL2=ewbankkit/rust-amazonlinux:1.48.0-2.0.20200722.0
 
 .PHONY: all image_al push_al image_al2 push_al2
 


### PR DESCRIPTION
Closes https://github.com/ewbankkit/rust-amazonlinux/issues/10.

```console
$ make image_al
docker build --file Dockerfile.al --tag rust:1.48.0-amazonlinux2018.03.0.20200602.1 .
Sending build context to Docker daemon  131.1kB
Step 1/5 : FROM amazonlinux:2018.03.0.20200602.1
 ---> bc9c4a7803b5
Step 2/5 : LABEL maintainer="Kit Ewbank <Kit_Ewbank@hotmail.com>"
 ---> Using cache
 ---> cb7d1b3b8ea1
Step 3/5 : ENV RUSTUP_HOME=/usr/local/rustup     CARGO_HOME=/usr/local/cargo     PATH=/usr/local/cargo/bin:$PATH     RUST_VERSION=1.48.0
 ---> Running in de54084104e6
Removing intermediate container de54084104e6
 ---> bde5368197b2
Step 4/5 : RUN yum install -y gcc gcc-c++ openssl-devel;     curl https://sh.rustup.rs -sSf | sh -s -- --no-modify-path --profile minimal --default-toolchain $RUST_VERSION -y;     chmod -R a+w $RUSTUP_HOME $CARGO_HOME;     rustup --version;     cargo --version;     rustc --version;
 ---> Running in 9b861003bd4c
Loaded plugins: ovl, priorities
Resolving Dependencies
--> Running transaction check
---> Package gcc.noarch 0:4.8.5-1.22.amzn1 will be installed
--> Processing Dependency: gcc48 >= 4.8.5 for package: gcc-4.8.5-1.22.amzn1.noarch
---> Package gcc-c++.noarch 0:4.8.5-1.22.amzn1 will be installed
--> Processing Dependency: gcc48-c++ >= 4.8.5 for package: gcc-c++-4.8.5-1.22.amzn1.noarch
--> Processing Dependency: libstdc++48 >= 4.8.5 for package: gcc-c++-4.8.5-1.22.amzn1.noarch
---> Package openssl-devel.x86_64 1:1.0.2k-16.152.amzn1 will be installed
--> Processing Dependency: openssl(x86-64) = 1:1.0.2k-16.152.amzn1 for package: 1:openssl-devel-1.0.2k-16.152.amzn1.x86_64
--> Processing Dependency: zlib-devel(x86-64) for package: 1:openssl-devel-1.0.2k-16.152.amzn1.x86_64
--> Processing Dependency: krb5-devel(x86-64) for package: 1:openssl-devel-1.0.2k-16.152.amzn1.x86_64
--> Running transaction check
---> Package gcc48.x86_64 0:4.8.5-28.142.amzn1 will be installed
--> Processing Dependency: libgcc48(x86-64) = 4.8.5 for package: gcc48-4.8.5-28.142.amzn1.x86_64
--> Processing Dependency: cpp48(x86-64) = 4.8.5-28.142.amzn1 for package: gcc48-4.8.5-28.142.amzn1.x86_64
--> Processing Dependency: libgomp(x86-64) >= 4.8.5-28.142.amzn1 for package: gcc48-4.8.5-28.142.amzn1.x86_64
--> Processing Dependency: glibc-devel(x86-64) >= 2.2.90-12 for package: gcc48-4.8.5-28.142.amzn1.x86_64
--> Processing Dependency: binutils >= 2.20.51.0.2-12 for package: gcc48-4.8.5-28.142.amzn1.x86_64
--> Processing Dependency: libmpfr.so.4()(64bit) for package: gcc48-4.8.5-28.142.amzn1.x86_64
--> Processing Dependency: libmpc.so.3()(64bit) for package: gcc48-4.8.5-28.142.amzn1.x86_64
--> Processing Dependency: libgomp.so.1()(64bit) for package: gcc48-4.8.5-28.142.amzn1.x86_64
---> Package gcc48-c++.x86_64 0:4.8.5-28.142.amzn1 will be installed
---> Package krb5-devel.x86_64 0:1.15.1-46.48.amzn1 will be installed
--> Processing Dependency: libkadm5(x86-64) = 1.15.1-46.48.amzn1 for package: krb5-devel-1.15.1-46.48.amzn1.x86_64
--> Processing Dependency: libverto-devel for package: krb5-devel-1.15.1-46.48.amzn1.x86_64
--> Processing Dependency: libselinux-devel for package: krb5-devel-1.15.1-46.48.amzn1.x86_64
--> Processing Dependency: libcom_err-devel for package: krb5-devel-1.15.1-46.48.amzn1.x86_64
--> Processing Dependency: keyutils-libs-devel for package: krb5-devel-1.15.1-46.48.amzn1.x86_64
---> Package libstdc++48.x86_64 0:4.8.5-28.142.amzn1 will be installed
---> Package openssl.x86_64 1:1.0.2k-16.151.amzn1 will be updated
---> Package openssl.x86_64 1:1.0.2k-16.152.amzn1 will be an update
---> Package zlib-devel.x86_64 0:1.2.8-7.18.amzn1 will be installed
--> Running transaction check
---> Package binutils.x86_64 0:2.25.1-31.base.66.amzn1 will be installed
---> Package cpp48.x86_64 0:4.8.5-28.142.amzn1 will be installed
---> Package glibc-devel.x86_64 0:2.17-292.180.amzn1 will be installed
--> Processing Dependency: glibc-headers = 2.17-292.180.amzn1 for package: glibc-devel-2.17-292.180.amzn1.x86_64
--> Processing Dependency: glibc-headers for package: glibc-devel-2.17-292.180.amzn1.x86_64
---> Package keyutils-libs-devel.x86_64 0:1.5.8-3.12.amzn1 will be installed
---> Package libcom_err-devel.x86_64 0:1.43.5-2.43.amzn1 will be installed
---> Package libgcc48.x86_64 0:4.8.5-28.142.amzn1 will be installed
---> Package libgomp.x86_64 0:6.4.1-1.45.amzn1 will be installed
---> Package libkadm5.x86_64 0:1.15.1-46.48.amzn1 will be installed
---> Package libmpc.x86_64 0:1.0.1-3.3.amzn1 will be installed
---> Package libselinux-devel.x86_64 0:2.1.10-3.22.amzn1 will be installed
--> Processing Dependency: libsepol-devel >= 2.1.5-1 for package: libselinux-devel-2.1.10-3.22.amzn1.x86_64
--> Processing Dependency: pkgconfig(libsepol) for package: libselinux-devel-2.1.10-3.22.amzn1.x86_64
---> Package libverto-devel.x86_64 0:0.2.5-4.9.amzn1 will be installed
---> Package mpfr.x86_64 0:3.1.1-4.14.amzn1 will be installed
--> Running transaction check
---> Package glibc-headers.x86_64 0:2.17-292.180.amzn1 will be installed
--> Processing Dependency: kernel-headers >= 2.2.1 for package: glibc-headers-2.17-292.180.amzn1.x86_64
--> Processing Dependency: kernel-headers for package: glibc-headers-2.17-292.180.amzn1.x86_64
---> Package libsepol-devel.x86_64 0:2.1.7-3.12.amzn1 will be installed
--> Running transaction check
---> Package kernel-headers.x86_64 0:4.14.203-116.332.amzn1 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

================================================================================
 Package               Arch     Version                    Repository      Size
================================================================================
Installing:
 gcc                   noarch   4.8.5-1.22.amzn1           amzn-main      4.1 k
 gcc-c++               noarch   4.8.5-1.22.amzn1           amzn-main      4.0 k
 openssl-devel         x86_64   1:1.0.2k-16.152.amzn1      amzn-updates   1.7 M
Installing for dependencies:
 binutils              x86_64   2.25.1-31.base.66.amzn1    amzn-main      7.2 M
 cpp48                 x86_64   4.8.5-28.142.amzn1         amzn-updates   6.7 M
 gcc48                 x86_64   4.8.5-28.142.amzn1         amzn-updates    18 M
 gcc48-c++             x86_64   4.8.5-28.142.amzn1         amzn-updates   9.8 M
 glibc-devel           x86_64   2.17-292.180.amzn1         amzn-updates   1.2 M
 glibc-headers         x86_64   2.17-292.180.amzn1         amzn-updates   763 k
 kernel-headers        x86_64   4.14.203-116.332.amzn1     amzn-updates   1.3 M
 keyutils-libs-devel   x86_64   1.5.8-3.12.amzn1           amzn-main       37 k
 krb5-devel            x86_64   1.15.1-46.48.amzn1         amzn-updates   293 k
 libcom_err-devel      x86_64   1.43.5-2.43.amzn1          amzn-updates    36 k
 libgcc48              x86_64   4.8.5-28.142.amzn1         amzn-updates   155 k
 libgomp               x86_64   6.4.1-1.45.amzn1           amzn-main      204 k
 libkadm5              x86_64   1.15.1-46.48.amzn1         amzn-updates   203 k
 libmpc                x86_64   1.0.1-3.3.amzn1            amzn-main       53 k
 libselinux-devel      x86_64   2.1.10-3.22.amzn1          amzn-main      157 k
 libsepol-devel        x86_64   2.1.7-3.12.amzn1           amzn-main       70 k
 libstdc++48           x86_64   4.8.5-28.142.amzn1         amzn-updates   408 k
 libverto-devel        x86_64   0.2.5-4.9.amzn1            amzn-main       11 k
 mpfr                  x86_64   3.1.1-4.14.amzn1           amzn-main      237 k
 zlib-devel            x86_64   1.2.8-7.18.amzn1           amzn-main       53 k
Updating for dependencies:
 openssl               x86_64   1:1.0.2k-16.152.amzn1      amzn-updates   1.8 M

Transaction Summary
================================================================================
Install  3 Packages (+20 Dependent packages)
Upgrade             (  1 Dependent package)

Total download size: 50 M
Downloading packages:
--------------------------------------------------------------------------------
Total                                              6.7 MB/s |  50 MB  00:07     
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Installing : mpfr-3.1.1-4.14.amzn1.x86_64                                1/25 
  Installing : libmpc-1.0.1-3.3.amzn1.x86_64                               2/25 
  Installing : libgcc48-4.8.5-28.142.amzn1.x86_64                          3/25 
  Installing : libstdc++48-4.8.5-28.142.amzn1.x86_64                       4/25 
  Installing : binutils-2.25.1-31.base.66.amzn1.x86_64                     5/25 
  Installing : cpp48-4.8.5-28.142.amzn1.x86_64                             6/25 
  Updating   : 1:openssl-1.0.2k-16.152.amzn1.x86_64                        7/25 
  Installing : libcom_err-devel-1.43.5-2.43.amzn1.x86_64                   8/25 
  Installing : libverto-devel-0.2.5-4.9.amzn1.x86_64                       9/25 
  Installing : libsepol-devel-2.1.7-3.12.amzn1.x86_64                     10/25 
  Installing : libselinux-devel-2.1.10-3.22.amzn1.x86_64                  11/25 
  Installing : libgomp-6.4.1-1.45.amzn1.x86_64                            12/25 
  Installing : kernel-headers-4.14.203-116.332.amzn1.x86_64               13/25 
  Installing : glibc-headers-2.17-292.180.amzn1.x86_64                    14/25 
  Installing : glibc-devel-2.17-292.180.amzn1.x86_64                      15/25 
  Installing : gcc48-4.8.5-28.142.amzn1.x86_64                            16/25 
  Installing : gcc-4.8.5-1.22.amzn1.noarch                                17/25 
  Installing : gcc48-c++-4.8.5-28.142.amzn1.x86_64                        18/25 
  Installing : libkadm5-1.15.1-46.48.amzn1.x86_64                         19/25 
  Installing : zlib-devel-1.2.8-7.18.amzn1.x86_64                         20/25 
  Installing : keyutils-libs-devel-1.5.8-3.12.amzn1.x86_64                21/25 
  Installing : krb5-devel-1.15.1-46.48.amzn1.x86_64                       22/25 
  Installing : 1:openssl-devel-1.0.2k-16.152.amzn1.x86_64                 23/25 
  Installing : gcc-c++-4.8.5-1.22.amzn1.noarch                            24/25 
  Cleanup    : 1:openssl-1.0.2k-16.151.amzn1.x86_64                       25/25 
  Verifying  : gcc-4.8.5-1.22.amzn1.noarch                                 1/25 
  Verifying  : libstdc++48-4.8.5-28.142.amzn1.x86_64                       2/25 
  Verifying  : gcc-c++-4.8.5-1.22.amzn1.noarch                             3/25 
  Verifying  : glibc-devel-2.17-292.180.amzn1.x86_64                       4/25 
  Verifying  : mpfr-3.1.1-4.14.amzn1.x86_64                                5/25 
  Verifying  : libselinux-devel-2.1.10-3.22.amzn1.x86_64                   6/25 
  Verifying  : gcc48-4.8.5-28.142.amzn1.x86_64                             7/25 
  Verifying  : keyutils-libs-devel-1.5.8-3.12.amzn1.x86_64                 8/25 
  Verifying  : zlib-devel-1.2.8-7.18.amzn1.x86_64                          9/25 
  Verifying  : krb5-devel-1.15.1-46.48.amzn1.x86_64                       10/25 
  Verifying  : cpp48-4.8.5-28.142.amzn1.x86_64                            11/25 
  Verifying  : glibc-headers-2.17-292.180.amzn1.x86_64                    12/25 
  Verifying  : gcc48-c++-4.8.5-28.142.amzn1.x86_64                        13/25 
  Verifying  : libkadm5-1.15.1-46.48.amzn1.x86_64                         14/25 
  Verifying  : kernel-headers-4.14.203-116.332.amzn1.x86_64               15/25 
  Verifying  : libmpc-1.0.1-3.3.amzn1.x86_64                              16/25 
  Verifying  : libgomp-6.4.1-1.45.amzn1.x86_64                            17/25 
  Verifying  : 1:openssl-devel-1.0.2k-16.152.amzn1.x86_64                 18/25 
  Verifying  : libsepol-devel-2.1.7-3.12.amzn1.x86_64                     19/25 
  Verifying  : libverto-devel-0.2.5-4.9.amzn1.x86_64                      20/25 
  Verifying  : libcom_err-devel-1.43.5-2.43.amzn1.x86_64                  21/25 
  Verifying  : binutils-2.25.1-31.base.66.amzn1.x86_64                    22/25 
  Verifying  : 1:openssl-1.0.2k-16.152.amzn1.x86_64                       23/25 
  Verifying  : libgcc48-4.8.5-28.142.amzn1.x86_64                         24/25 
  Verifying  : 1:openssl-1.0.2k-16.151.amzn1.x86_64                       25/25 

Installed:
  gcc.noarch 0:4.8.5-1.22.amzn1               gcc-c++.noarch 0:4.8.5-1.22.amzn1 
  openssl-devel.x86_64 1:1.0.2k-16.152.amzn1 

Dependency Installed:
  binutils.x86_64 0:2.25.1-31.base.66.amzn1                                     
  cpp48.x86_64 0:4.8.5-28.142.amzn1                                             
  gcc48.x86_64 0:4.8.5-28.142.amzn1                                             
  gcc48-c++.x86_64 0:4.8.5-28.142.amzn1                                         
  glibc-devel.x86_64 0:2.17-292.180.amzn1                                       
  glibc-headers.x86_64 0:2.17-292.180.amzn1                                     
  kernel-headers.x86_64 0:4.14.203-116.332.amzn1                                
  keyutils-libs-devel.x86_64 0:1.5.8-3.12.amzn1                                 
  krb5-devel.x86_64 0:1.15.1-46.48.amzn1                                        
  libcom_err-devel.x86_64 0:1.43.5-2.43.amzn1                                   
  libgcc48.x86_64 0:4.8.5-28.142.amzn1                                          
  libgomp.x86_64 0:6.4.1-1.45.amzn1                                             
  libkadm5.x86_64 0:1.15.1-46.48.amzn1                                          
  libmpc.x86_64 0:1.0.1-3.3.amzn1                                               
  libselinux-devel.x86_64 0:2.1.10-3.22.amzn1                                   
  libsepol-devel.x86_64 0:2.1.7-3.12.amzn1                                      
  libstdc++48.x86_64 0:4.8.5-28.142.amzn1                                       
  libverto-devel.x86_64 0:0.2.5-4.9.amzn1                                       
  mpfr.x86_64 0:3.1.1-4.14.amzn1                                                
  zlib-devel.x86_64 0:1.2.8-7.18.amzn1                                          

Dependency Updated:
  openssl.x86_64 1:1.0.2k-16.152.amzn1                                          

Complete!
info: downloading installer
info: profile set to 'minimal'
info: default host triple is x86_64-unknown-linux-gnu
info: syncing channel updates for '1.48.0-x86_64-unknown-linux-gnu'
info: latest update on 2020-11-19, rust version 1.48.0 (7eac88abb 2020-11-16)
info: downloading component 'cargo'
info: downloading component 'rust-std'
info: downloading component 'rustc'
info: installing component 'cargo'
info: using up to 500.0 MiB of RAM to unpack components
info: installing component 'rust-std'
info: installing component 'rustc'

info: default toolchain set to '1.48.0-x86_64-unknown-linux-gnu'
  1.48.0-x86_64-unknown-linux-gnu installed - rustc 1.48.0 (7eac88abb 2020-11-16)


Rust is installed now. Great!

To get started you need Cargo's bin directory (/usr/local/cargo/bin) in your 
PATH
environment variable.

To configure your current shell, run:
source /usr/local/cargo/env
rustup 1.23.1 (3df2264a9 2020-11-30)
info: This is the version for the rustup toolchain manager, not the rustc compiler.
info: The currently active `rustc` version is `rustc 1.48.0 (7eac88abb 2020-11-16)`
cargo 1.48.0 (65cbdd2dc 2020-10-14)
rustc 1.48.0 (7eac88abb 2020-11-16)
Removing intermediate container 9b861003bd4c
 ---> b4652a9a5860
Step 5/5 : WORKDIR /volume
 ---> Running in e7e9bef00801
Removing intermediate container e7e9bef00801
 ---> 277425b94f8a
Successfully built 277425b94f8a
Successfully tagged rust:1.48.0-amazonlinux2018.03.0.20200602.1
docker tag rust:1.48.0-amazonlinux2018.03.0.20200602.1 ewbankkit/rust-amazonlinux:1.48.0-2018.03.0.20200602.1
$ make push_al
docker build --file Dockerfile.al --tag rust:1.48.0-amazonlinux2018.03.0.20200602.1 .
Sending build context to Docker daemon  131.1kB
Step 1/5 : FROM amazonlinux:2018.03.0.20200602.1
 ---> bc9c4a7803b5
Step 2/5 : LABEL maintainer="Kit Ewbank <Kit_Ewbank@hotmail.com>"
 ---> Using cache
 ---> cb7d1b3b8ea1
Step 3/5 : ENV RUSTUP_HOME=/usr/local/rustup     CARGO_HOME=/usr/local/cargo     PATH=/usr/local/cargo/bin:$PATH     RUST_VERSION=1.48.0
 ---> Using cache
 ---> bde5368197b2
Step 4/5 : RUN yum install -y gcc gcc-c++ openssl-devel;     curl https://sh.rustup.rs -sSf | sh -s -- --no-modify-path --profile minimal --default-toolchain $RUST_VERSION -y;     chmod -R a+w $RUSTUP_HOME $CARGO_HOME;     rustup --version;     cargo --version;     rustc --version;
 ---> Using cache
 ---> b4652a9a5860
Step 5/5 : WORKDIR /volume
 ---> Using cache
 ---> 277425b94f8a
Successfully built 277425b94f8a
Successfully tagged rust:1.48.0-amazonlinux2018.03.0.20200602.1
docker tag rust:1.48.0-amazonlinux2018.03.0.20200602.1 ewbankkit/rust-amazonlinux:1.48.0-2018.03.0.20200602.1
docker push ewbankkit/rust-amazonlinux:1.48.0-2018.03.0.20200602.1
The push refers to repository [docker.io/ewbankkit/rust-amazonlinux]
2814521b8329: Pushed 
d7f943748dec: Pushed 
c049279232a7: Layer already exists 
1.48.0-2018.03.0.20200602.1: digest: sha256:0904c029b6431fe79ce7eeca0d16bf0f5ce20d4f906c79247ac581a0f8a4c88d size: 949
$ make image_al2
docker build --file Dockerfile.al2 --tag rust:1.48.0-amazonlinux2.0.20200722.0 .
Sending build context to Docker daemon  131.1kB
Step 1/5 : FROM amazonlinux:2.0.20200722.0
 ---> ba2cc467a2bc
Step 2/5 : LABEL maintainer="Kit Ewbank <Kit_Ewbank@hotmail.com>"
 ---> Using cache
 ---> c19e3a0de36d
Step 3/5 : ENV RUSTUP_HOME=/usr/local/rustup     CARGO_HOME=/usr/local/cargo     PATH=/usr/local/cargo/bin:$PATH     RUST_VERSION=1.48.0
 ---> Running in 6e8b95b04e9c
Removing intermediate container 6e8b95b04e9c
 ---> 231fde3a1cd2
Step 4/5 : RUN yum install -y gcc gcc-c++ openssl-devel;     curl https://sh.rustup.rs -sSf | sh -s -- --no-modify-path --profile minimal --default-toolchain $RUST_VERSION -y;     chmod -R a+w $RUSTUP_HOME $CARGO_HOME;     rustup --version;     cargo --version;     rustc --version;
 ---> Running in 830e7cb82155
Loaded plugins: ovl, priorities
Resolving Dependencies
--> Running transaction check
---> Package gcc.x86_64 0:7.3.1-11.amzn2 will be installed
--> Processing Dependency: libgomp = 7.3.1-11.amzn2 for package: gcc-7.3.1-11.amzn2.x86_64
--> Processing Dependency: cpp = 7.3.1-11.amzn2 for package: gcc-7.3.1-11.amzn2.x86_64
--> Processing Dependency: libgcc >= 7.3.1-11.amzn2 for package: gcc-7.3.1-11.amzn2.x86_64
--> Processing Dependency: glibc-devel >= 2.2.90-12 for package: gcc-7.3.1-11.amzn2.x86_64
--> Processing Dependency: binutils >= 2.24 for package: gcc-7.3.1-11.amzn2.x86_64
--> Processing Dependency: libmpfr.so.4()(64bit) for package: gcc-7.3.1-11.amzn2.x86_64
--> Processing Dependency: libmpc.so.3()(64bit) for package: gcc-7.3.1-11.amzn2.x86_64
--> Processing Dependency: libgomp.so.1()(64bit) for package: gcc-7.3.1-11.amzn2.x86_64
---> Package gcc-c++.x86_64 0:7.3.1-11.amzn2 will be installed
--> Processing Dependency: libstdc++(x86-64) = 7.3.1-11.amzn2 for package: gcc-c++-7.3.1-11.amzn2.x86_64
---> Package openssl-devel.x86_64 1:1.0.2k-19.amzn2.0.4 will be installed
--> Processing Dependency: openssl-libs(x86-64) = 1:1.0.2k-19.amzn2.0.4 for package: 1:openssl-devel-1.0.2k-19.amzn2.0.4.x86_64
--> Processing Dependency: zlib-devel(x86-64) for package: 1:openssl-devel-1.0.2k-19.amzn2.0.4.x86_64
--> Processing Dependency: pkgconfig for package: 1:openssl-devel-1.0.2k-19.amzn2.0.4.x86_64
--> Processing Dependency: krb5-devel(x86-64) for package: 1:openssl-devel-1.0.2k-19.amzn2.0.4.x86_64
--> Processing Dependency: /usr/bin/pkg-config for package: 1:openssl-devel-1.0.2k-19.amzn2.0.4.x86_64
--> Running transaction check
---> Package binutils.x86_64 0:2.29.1-30.amzn2 will be installed
---> Package cpp.x86_64 0:7.3.1-11.amzn2 will be installed
---> Package glibc-devel.x86_64 0:2.26-39.amzn2 will be installed
--> Processing Dependency: glibc-headers = 2.26-39.amzn2 for package: glibc-devel-2.26-39.amzn2.x86_64
--> Processing Dependency: glibc = 2.26-39.amzn2 for package: glibc-devel-2.26-39.amzn2.x86_64
--> Processing Dependency: glibc-headers for package: glibc-devel-2.26-39.amzn2.x86_64
---> Package krb5-devel.x86_64 0:1.15.1-37.amzn2.2.2 will be installed
--> Processing Dependency: libkadm5(x86-64) = 1.15.1-37.amzn2.2.2 for package: krb5-devel-1.15.1-37.amzn2.2.2.x86_64
--> Processing Dependency: libverto-devel for package: krb5-devel-1.15.1-37.amzn2.2.2.x86_64
--> Processing Dependency: libselinux-devel for package: krb5-devel-1.15.1-37.amzn2.2.2.x86_64
--> Processing Dependency: libcom_err-devel for package: krb5-devel-1.15.1-37.amzn2.2.2.x86_64
--> Processing Dependency: keyutils-libs-devel for package: krb5-devel-1.15.1-37.amzn2.2.2.x86_64
---> Package libgcc.x86_64 0:7.3.1-9.amzn2 will be updated
---> Package libgcc.x86_64 0:7.3.1-11.amzn2 will be an update
---> Package libgomp.x86_64 0:7.3.1-11.amzn2 will be installed
---> Package libmpc.x86_64 0:1.0.1-3.amzn2.0.2 will be installed
---> Package libstdc++.x86_64 0:7.3.1-9.amzn2 will be updated
---> Package libstdc++.x86_64 0:7.3.1-11.amzn2 will be an update
---> Package mpfr.x86_64 0:3.1.1-4.amzn2.0.2 will be installed
---> Package openssl-libs.x86_64 1:1.0.2k-19.amzn2.0.3 will be updated
---> Package openssl-libs.x86_64 1:1.0.2k-19.amzn2.0.4 will be an update
---> Package pkgconfig.x86_64 1:0.27.1-4.amzn2.0.2 will be installed
---> Package zlib-devel.x86_64 0:1.2.7-18.amzn2 will be installed
--> Running transaction check
---> Package glibc.x86_64 0:2.26-35.amzn2 will be updated
--> Processing Dependency: glibc = 2.26-35.amzn2 for package: glibc-langpack-en-2.26-35.amzn2.x86_64
--> Processing Dependency: glibc = 2.26-35.amzn2 for package: glibc-minimal-langpack-2.26-35.amzn2.x86_64
--> Processing Dependency: glibc = 2.26-35.amzn2 for package: glibc-common-2.26-35.amzn2.x86_64
--> Processing Dependency: glibc(x86-64) = 2.26-35.amzn2 for package: libcrypt-2.26-35.amzn2.x86_64
---> Package glibc.x86_64 0:2.26-39.amzn2 will be an update
---> Package glibc-headers.x86_64 0:2.26-39.amzn2 will be installed
--> Processing Dependency: kernel-headers >= 2.2.1 for package: glibc-headers-2.26-39.amzn2.x86_64
--> Processing Dependency: kernel-headers for package: glibc-headers-2.26-39.amzn2.x86_64
---> Package keyutils-libs-devel.x86_64 0:1.5.8-3.amzn2.0.2 will be installed
---> Package libcom_err-devel.x86_64 0:1.42.9-19.amzn2 will be installed
--> Processing Dependency: libcom_err(x86-64) = 1.42.9-19.amzn2 for package: libcom_err-devel-1.42.9-19.amzn2.x86_64
---> Package libkadm5.x86_64 0:1.15.1-37.amzn2.2.2 will be installed
---> Package libselinux-devel.x86_64 0:2.5-12.amzn2.0.2 will be installed
--> Processing Dependency: libsepol-devel(x86-64) >= 2.5-6 for package: libselinux-devel-2.5-12.amzn2.0.2.x86_64
--> Processing Dependency: pkgconfig(libsepol) for package: libselinux-devel-2.5-12.amzn2.0.2.x86_64
--> Processing Dependency: pkgconfig(libpcre) for package: libselinux-devel-2.5-12.amzn2.0.2.x86_64
---> Package libverto-devel.x86_64 0:0.2.5-4.amzn2.0.2 will be installed
--> Running transaction check
---> Package glibc-common.x86_64 0:2.26-35.amzn2 will be updated
---> Package glibc-common.x86_64 0:2.26-39.amzn2 will be an update
---> Package glibc-langpack-en.x86_64 0:2.26-35.amzn2 will be updated
---> Package glibc-langpack-en.x86_64 0:2.26-39.amzn2 will be an update
---> Package glibc-minimal-langpack.x86_64 0:2.26-35.amzn2 will be updated
---> Package glibc-minimal-langpack.x86_64 0:2.26-39.amzn2 will be an update
---> Package kernel-headers.x86_64 0:4.14.209-160.335.amzn2 will be installed
---> Package libcom_err.x86_64 0:1.42.9-12.amzn2.0.2 will be updated
---> Package libcom_err.x86_64 0:1.42.9-19.amzn2 will be an update
---> Package libcrypt.x86_64 0:2.26-35.amzn2 will be updated
---> Package libcrypt.x86_64 0:2.26-39.amzn2 will be an update
---> Package libsepol-devel.x86_64 0:2.5-8.1.amzn2.0.2 will be installed
---> Package pcre-devel.x86_64 0:8.32-17.amzn2.0.2 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

================================================================================
 Package                  Arch     Version                   Repository    Size
================================================================================
Installing:
 gcc                      x86_64   7.3.1-11.amzn2            amzn2-core    22 M
 gcc-c++                  x86_64   7.3.1-11.amzn2            amzn2-core    13 M
 openssl-devel            x86_64   1:1.0.2k-19.amzn2.0.4     amzn2-core   1.5 M
Installing for dependencies:
 binutils                 x86_64   2.29.1-30.amzn2           amzn2-core   5.8 M
 cpp                      x86_64   7.3.1-11.amzn2            amzn2-core   9.2 M
 glibc-devel              x86_64   2.26-39.amzn2             amzn2-core   990 k
 glibc-headers            x86_64   2.26-39.amzn2             amzn2-core   511 k
 kernel-headers           x86_64   4.14.209-160.335.amzn2    amzn2-core   1.1 M
 keyutils-libs-devel      x86_64   1.5.8-3.amzn2.0.2         amzn2-core    37 k
 krb5-devel               x86_64   1.15.1-37.amzn2.2.2       amzn2-core   272 k
 libcom_err-devel         x86_64   1.42.9-19.amzn2           amzn2-core    32 k
 libgomp                  x86_64   7.3.1-11.amzn2            amzn2-core   204 k
 libkadm5                 x86_64   1.15.1-37.amzn2.2.2       amzn2-core   179 k
 libmpc                   x86_64   1.0.1-3.amzn2.0.2         amzn2-core    52 k
 libselinux-devel         x86_64   2.5-12.amzn2.0.2          amzn2-core   187 k
 libsepol-devel           x86_64   2.5-8.1.amzn2.0.2         amzn2-core    77 k
 libverto-devel           x86_64   0.2.5-4.amzn2.0.2         amzn2-core    12 k
 mpfr                     x86_64   3.1.1-4.amzn2.0.2         amzn2-core   208 k
 pcre-devel               x86_64   8.32-17.amzn2.0.2         amzn2-core   480 k
 pkgconfig                x86_64   1:0.27.1-4.amzn2.0.2      amzn2-core    54 k
 zlib-devel               x86_64   1.2.7-18.amzn2            amzn2-core    50 k
Updating for dependencies:
 glibc                    x86_64   2.26-39.amzn2             amzn2-core   3.3 M
 glibc-common             x86_64   2.26-39.amzn2             amzn2-core   769 k
 glibc-langpack-en        x86_64   2.26-39.amzn2             amzn2-core   285 k
 glibc-minimal-langpack   x86_64   2.26-39.amzn2             amzn2-core    28 k
 libcom_err               x86_64   1.42.9-19.amzn2           amzn2-core    42 k
 libcrypt                 x86_64   2.26-39.amzn2             amzn2-core    49 k
 libgcc                   x86_64   7.3.1-11.amzn2            amzn2-core    98 k
 libstdc++                x86_64   7.3.1-11.amzn2            amzn2-core   445 k
 openssl-libs             x86_64   1:1.0.2k-19.amzn2.0.4     amzn2-core   1.2 M

Transaction Summary
================================================================================
Install  3 Packages (+18 Dependent packages)
Upgrade             (  9 Dependent packages)

Total download size: 62 M
Downloading packages:
Delta RPMs disabled because /usr/bin/applydeltarpm not installed.
--------------------------------------------------------------------------------
Total                                               11 MB/s |  62 MB  00:05     
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Updating   : glibc-2.26-39.amzn2.x86_64                                  1/39 
  Updating   : glibc-common-2.26-39.amzn2.x86_64                           2/39 
  Updating   : glibc-minimal-langpack-2.26-39.amzn2.x86_64                 3/39 
  Installing : 1:pkgconfig-0.27.1-4.amzn2.0.2.x86_64                       4/39 
  Installing : mpfr-3.1.1-4.amzn2.0.2.x86_64                               5/39 
  Updating   : libcom_err-1.42.9-19.amzn2.x86_64                           6/39 
  Installing : libmpc-1.0.1-3.amzn2.0.2.x86_64                             7/39 
  Updating   : libgcc-7.3.1-11.amzn2.x86_64                                8/39 
  Updating   : libstdc++-7.3.1-11.amzn2.x86_64                             9/39 
  Installing : cpp-7.3.1-11.amzn2.x86_64                                  10/39 
  Installing : libcom_err-devel-1.42.9-19.amzn2.x86_64                    11/39 
  Updating   : 1:openssl-libs-1.0.2k-19.amzn2.0.4.x86_64                  12/39 
  Installing : libkadm5-1.15.1-37.amzn2.2.2.x86_64                        13/39 
  Installing : libsepol-devel-2.5-8.1.amzn2.0.2.x86_64                    14/39 
  Installing : libverto-devel-0.2.5-4.amzn2.0.2.x86_64                    15/39 
  Installing : zlib-devel-1.2.7-18.amzn2.x86_64                           16/39 
  Installing : pcre-devel-8.32-17.amzn2.0.2.x86_64                        17/39 
  Installing : libselinux-devel-2.5-12.amzn2.0.2.x86_64                   18/39 
  Installing : libgomp-7.3.1-11.amzn2.x86_64                              19/39 
  Updating   : libcrypt-2.26-39.amzn2.x86_64                              20/39 
  Installing : binutils-2.29.1-30.amzn2.x86_64                            21/39 
  Installing : keyutils-libs-devel-1.5.8-3.amzn2.0.2.x86_64               22/39 
  Installing : krb5-devel-1.15.1-37.amzn2.2.2.x86_64                      23/39 
  Installing : kernel-headers-4.14.209-160.335.amzn2.x86_64               24/39 
  Installing : glibc-headers-2.26-39.amzn2.x86_64                         25/39 
  Installing : glibc-devel-2.26-39.amzn2.x86_64                           26/39 
  Installing : gcc-7.3.1-11.amzn2.x86_64                                  27/39 
  Installing : gcc-c++-7.3.1-11.amzn2.x86_64                              28/39 
  Installing : 1:openssl-devel-1.0.2k-19.amzn2.0.4.x86_64                 29/39 
  Updating   : glibc-langpack-en-2.26-39.amzn2.x86_64                     30/39 
  Cleanup    : libstdc++-7.3.1-9.amzn2.x86_64                             31/39 
  Cleanup    : 1:openssl-libs-1.0.2k-19.amzn2.0.3.x86_64                  32/39 
  Cleanup    : glibc-langpack-en-2.26-35.amzn2.x86_64                     33/39 
  Cleanup    : libcom_err-1.42.9-12.amzn2.0.2.x86_64                      34/39 
  Cleanup    : libgcc-7.3.1-9.amzn2.x86_64                                35/39 
  Cleanup    : libcrypt-2.26-35.amzn2.x86_64                              36/39 
  Cleanup    : glibc-common-2.26-35.amzn2.x86_64                          37/39 
  Cleanup    : glibc-minimal-langpack-2.26-35.amzn2.x86_64                38/39 
  Cleanup    : glibc-2.26-35.amzn2.x86_64                                 39/39 
  Verifying  : gcc-7.3.1-11.amzn2.x86_64                                   1/39 
  Verifying  : 1:openssl-devel-1.0.2k-19.amzn2.0.4.x86_64                  2/39 
  Verifying  : libcom_err-devel-1.42.9-19.amzn2.x86_64                     3/39 
  Verifying  : gcc-c++-7.3.1-11.amzn2.x86_64                               4/39 
  Verifying  : 1:openssl-libs-1.0.2k-19.amzn2.0.4.x86_64                   5/39 
  Verifying  : libmpc-1.0.1-3.amzn2.0.2.x86_64                             6/39 
  Verifying  : glibc-common-2.26-39.amzn2.x86_64                           7/39 
  Verifying  : glibc-headers-2.26-39.amzn2.x86_64                          8/39 
  Verifying  : kernel-headers-4.14.209-160.335.amzn2.x86_64                9/39 
  Verifying  : glibc-langpack-en-2.26-39.amzn2.x86_64                     10/39 
  Verifying  : libkadm5-1.15.1-37.amzn2.2.2.x86_64                        11/39 
  Verifying  : libsepol-devel-2.5-8.1.amzn2.0.2.x86_64                    12/39 
  Verifying  : libgomp-7.3.1-11.amzn2.x86_64                              13/39 
  Verifying  : libverto-devel-0.2.5-4.amzn2.0.2.x86_64                    14/39 
  Verifying  : glibc-devel-2.26-39.amzn2.x86_64                           15/39 
  Verifying  : libgcc-7.3.1-11.amzn2.x86_64                               16/39 
  Verifying  : libcrypt-2.26-39.amzn2.x86_64                              17/39 
  Verifying  : zlib-devel-1.2.7-18.amzn2.x86_64                           18/39 
  Verifying  : mpfr-3.1.1-4.amzn2.0.2.x86_64                              19/39 
  Verifying  : glibc-2.26-39.amzn2.x86_64                                 20/39 
  Verifying  : libcom_err-1.42.9-19.amzn2.x86_64                          21/39 
  Verifying  : libselinux-devel-2.5-12.amzn2.0.2.x86_64                   22/39 
  Verifying  : 1:pkgconfig-0.27.1-4.amzn2.0.2.x86_64                      23/39 
  Verifying  : krb5-devel-1.15.1-37.amzn2.2.2.x86_64                      24/39 
  Verifying  : pcre-devel-8.32-17.amzn2.0.2.x86_64                        25/39 
  Verifying  : keyutils-libs-devel-1.5.8-3.amzn2.0.2.x86_64               26/39 
  Verifying  : binutils-2.29.1-30.amzn2.x86_64                            27/39 
  Verifying  : libstdc++-7.3.1-11.amzn2.x86_64                            28/39 
  Verifying  : glibc-minimal-langpack-2.26-39.amzn2.x86_64                29/39 
  Verifying  : cpp-7.3.1-11.amzn2.x86_64                                  30/39 
  Verifying  : glibc-minimal-langpack-2.26-35.amzn2.x86_64                31/39 
  Verifying  : 1:openssl-libs-1.0.2k-19.amzn2.0.3.x86_64                  32/39 
  Verifying  : libcrypt-2.26-35.amzn2.x86_64                              33/39 
  Verifying  : glibc-2.26-35.amzn2.x86_64                                 34/39 
  Verifying  : libcom_err-1.42.9-12.amzn2.0.2.x86_64                      35/39 
  Verifying  : libstdc++-7.3.1-9.amzn2.x86_64                             36/39 
  Verifying  : glibc-common-2.26-35.amzn2.x86_64                          37/39 
  Verifying  : libgcc-7.3.1-9.amzn2.x86_64                                38/39 
  Verifying  : glibc-langpack-en-2.26-35.amzn2.x86_64                     39/39 

Installed:
  gcc.x86_64 0:7.3.1-11.amzn2                  gcc-c++.x86_64 0:7.3.1-11.amzn2  
  openssl-devel.x86_64 1:1.0.2k-19.amzn2.0.4  

Dependency Installed:
  binutils.x86_64 0:2.29.1-30.amzn2                                             
  cpp.x86_64 0:7.3.1-11.amzn2                                                   
  glibc-devel.x86_64 0:2.26-39.amzn2                                            
  glibc-headers.x86_64 0:2.26-39.amzn2                                          
  kernel-headers.x86_64 0:4.14.209-160.335.amzn2                                
  keyutils-libs-devel.x86_64 0:1.5.8-3.amzn2.0.2                                
  krb5-devel.x86_64 0:1.15.1-37.amzn2.2.2                                       
  libcom_err-devel.x86_64 0:1.42.9-19.amzn2                                     
  libgomp.x86_64 0:7.3.1-11.amzn2                                               
  libkadm5.x86_64 0:1.15.1-37.amzn2.2.2                                         
  libmpc.x86_64 0:1.0.1-3.amzn2.0.2                                             
  libselinux-devel.x86_64 0:2.5-12.amzn2.0.2                                    
  libsepol-devel.x86_64 0:2.5-8.1.amzn2.0.2                                     
  libverto-devel.x86_64 0:0.2.5-4.amzn2.0.2                                     
  mpfr.x86_64 0:3.1.1-4.amzn2.0.2                                               
  pcre-devel.x86_64 0:8.32-17.amzn2.0.2                                         
  pkgconfig.x86_64 1:0.27.1-4.amzn2.0.2                                         
  zlib-devel.x86_64 0:1.2.7-18.amzn2                                            

Dependency Updated:
  glibc.x86_64 0:2.26-39.amzn2                                                  
  glibc-common.x86_64 0:2.26-39.amzn2                                           
  glibc-langpack-en.x86_64 0:2.26-39.amzn2                                      
  glibc-minimal-langpack.x86_64 0:2.26-39.amzn2                                 
  libcom_err.x86_64 0:1.42.9-19.amzn2                                           
  libcrypt.x86_64 0:2.26-39.amzn2                                               
  libgcc.x86_64 0:7.3.1-11.amzn2                                                
  libstdc++.x86_64 0:7.3.1-11.amzn2                                             
  openssl-libs.x86_64 1:1.0.2k-19.amzn2.0.4                                     

Complete!
info: downloading installer
info: profile set to 'minimal'
info: default host triple is x86_64-unknown-linux-gnu
info: syncing channel updates for '1.48.0-x86_64-unknown-linux-gnu'
info: latest update on 2020-11-19, rust version 1.48.0 (7eac88abb 2020-11-16)
info: downloading component 'cargo'
info: downloading component 'rust-std'
info: downloading component 'rustc'
info: installing component 'cargo'
info: using up to 500.0 MiB of RAM to unpack components
info: installing component 'rust-std'
info: installing component 'rustc'
info: default toolchain set to '1.48.0-x86_64-unknown-linux-gnu'

  1.48.0-x86_64-unknown-linux-gnu installed - rustc 1.48.0 (7eac88abb 2020-11-16)


Rust is installed now. Great!

To get started you need Cargo's bin directory (/usr/local/cargo/bin) in your 
PATH
environment variable.

To configure your current shell, run:
source /usr/local/cargo/env
rustup 1.23.1 (3df2264a9 2020-11-30)
info: This is the version for the rustup toolchain manager, not the rustc compiler.
info: The currently active `rustc` version is `rustc 1.48.0 (7eac88abb 2020-11-16)`
cargo 1.48.0 (65cbdd2dc 2020-10-14)
rustc 1.48.0 (7eac88abb 2020-11-16)
Removing intermediate container 830e7cb82155
 ---> e95e9edbc247
Step 5/5 : WORKDIR /volume
 ---> Running in e48e04491dd9
Removing intermediate container e48e04491dd9
 ---> f44093f120f9
Successfully built f44093f120f9
Successfully tagged rust:1.48.0-amazonlinux2.0.20200722.0
docker tag rust:1.48.0-amazonlinux2.0.20200722.0 ewbankkit/rust-amazonlinux:1.48.0-2.0.20200722.0
$ make push_al2
docker build --file Dockerfile.al2 --tag rust:1.48.0-amazonlinux2.0.20200722.0 .
Sending build context to Docker daemon  131.1kB
Step 1/5 : FROM amazonlinux:2.0.20200722.0
 ---> ba2cc467a2bc
Step 2/5 : LABEL maintainer="Kit Ewbank <Kit_Ewbank@hotmail.com>"
 ---> Using cache
 ---> c19e3a0de36d
Step 3/5 : ENV RUSTUP_HOME=/usr/local/rustup     CARGO_HOME=/usr/local/cargo     PATH=/usr/local/cargo/bin:$PATH     RUST_VERSION=1.48.0
 ---> Using cache
 ---> 231fde3a1cd2
Step 4/5 : RUN yum install -y gcc gcc-c++ openssl-devel;     curl https://sh.rustup.rs -sSf | sh -s -- --no-modify-path --profile minimal --default-toolchain $RUST_VERSION -y;     chmod -R a+w $RUSTUP_HOME $CARGO_HOME;     rustup --version;     cargo --version;     rustc --version;
 ---> Using cache
 ---> e95e9edbc247
Step 5/5 : WORKDIR /volume
 ---> Using cache
 ---> f44093f120f9
Successfully built f44093f120f9
Successfully tagged rust:1.48.0-amazonlinux2.0.20200722.0
docker tag rust:1.48.0-amazonlinux2.0.20200722.0 ewbankkit/rust-amazonlinux:1.48.0-2.0.20200722.0
docker push ewbankkit/rust-amazonlinux:1.48.0-2.0.20200722.0
The push refers to repository [docker.io/ewbankkit/rust-amazonlinux]
bd40f2562de1: Pushed 
45c7ceff0e53: Pushed 
50c3cd231426: Layer already exists 
1.48.0-2.0.20200722.0: digest: sha256:13f5a0140e7b48c5f14ef25b6185663fb082b8d6404c151250ba3d3d0a7e2997 size: 949
```