### PR TITLE
Build Rust 1.49.0 images

### DIFF
--- a/Dockerfile.al
+++ b/Dockerfile.al
@@ -1,12 +1,12 @@
 # Build image for building with Rust on Amazon Linux, suitable for custom AWS Lambda runtimes.
 
-FROM amazonlinux:2018.03.0.20200602.1
+FROM amazonlinux:2018.03.0.20201209.1
 LABEL maintainer="Kit Ewbank <Kit_Ewbank@hotmail.com>"
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.48.0
+    RUST_VERSION=1.49.0
 
 RUN yum install -y gcc gcc-c++ openssl-devel; \
     curl https://sh.rustup.rs -sSf | sh -s -- --no-modify-path --profile minimal --default-toolchain $RUST_VERSION -y; \

--- a/Dockerfile.al2
+++ b/Dockerfile.al2
@@ -1,12 +1,12 @@
 # Build image for building with Rust on Amazon Linux 2, suitable for custom AWS Lambda runtimes.
 
-FROM amazonlinux:2.0.20200722.0
+FROM amazonlinux:2.0.20201218.1
 LABEL maintainer="Kit Ewbank <Kit_Ewbank@hotmail.com>"
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.48.0
+    RUST_VERSION=1.49.0
 
 RUN yum install -y gcc gcc-c++ openssl-devel; \
     curl https://sh.rustup.rs -sSf | sh -s -- --no-modify-path --profile minimal --default-toolchain $RUST_VERSION -y; \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-LOCAL_AL=rust:1.48.0-amazonlinux2018.03.0.20200602.1
-REMOTE_AL=ewbankkit/rust-amazonlinux:1.48.0-2018.03.0.20200602.1
-LOCAL_AL2=rust:1.48.0-amazonlinux2.0.20200722.0
-REMOTE_AL2=ewbankkit/rust-amazonlinux:1.48.0-2.0.20200722.0
+LOCAL_AL=rust:1.49.0-amazonlinux2018.03.0.20201209.1
+REMOTE_AL=ewbankkit/rust-amazonlinux:1.49.0-2018.03.0.20201209.1
+LOCAL_AL2=rust:1.49.0-amazonlinux2.0.20201218.1
+REMOTE_AL2=ewbankkit/rust-amazonlinux:1.49.0-2.0.20201218.1
 
 .PHONY: all image_al push_al image_al2 push_al2
 


### PR DESCRIPTION
Closes https://github.com/ewbankkit/rust-amazonlinux/issues/12.

```console
$ make image_al
docker build --file Dockerfile.al --tag rust:1.49.0-amazonlinux2018.03.0.20201209.1 .
Sending build context to Docker daemon  141.3kB
Step 1/5 : FROM amazonlinux:2018.03.0.20201209.1
2018.03.0.20201209.1: Pulling from library/amazonlinux
0d94e7de59b4: Pull complete 
Digest: sha256:99cd0e8755feee09c253bc0ffa9a2785cdd5c2de929859fd424944883a3777d7
Status: Downloaded newer image for amazonlinux:2018.03.0.20201209.1
 ---> ff3a6f913fa9
Step 2/5 : LABEL maintainer="Kit Ewbank <Kit_Ewbank@hotmail.com>"
 ---> Running in 93e0a25f076b
Removing intermediate container 93e0a25f076b
 ---> 12a1c6f743cf
Step 3/5 : ENV RUSTUP_HOME=/usr/local/rustup     CARGO_HOME=/usr/local/cargo     PATH=/usr/local/cargo/bin:$PATH     RUST_VERSION=1.49.0
 ---> Running in f0100b3fe61b
Removing intermediate container f0100b3fe61b
 ---> 2428671b2289
Step 4/5 : RUN yum install -y gcc gcc-c++ openssl-devel;     curl https://sh.rustup.rs -sSf | sh -s -- --no-modify-path --profile minimal --default-toolchain $RUST_VERSION -y;     chmod -R a+w $RUSTUP_HOME $CARGO_HOME;     rustup --version;     cargo --version;     rustc --version;
 ---> Running in 36d0156a66a6
Loaded plugins: ovl, priorities
Resolving Dependencies
--> Running transaction check
---> Package gcc.noarch 0:4.8.5-1.22.amzn1 will be installed
--> Processing Dependency: gcc48 >= 4.8.5 for package: gcc-4.8.5-1.22.amzn1.noarch
---> Package gcc-c++.noarch 0:4.8.5-1.22.amzn1 will be installed
--> Processing Dependency: gcc48-c++ >= 4.8.5 for package: gcc-c++-4.8.5-1.22.amzn1.noarch
--> Processing Dependency: libstdc++48 >= 4.8.5 for package: gcc-c++-4.8.5-1.22.amzn1.noarch
---> Package openssl-devel.x86_64 1:1.0.2k-16.152.amzn1 will be installed
--> Processing Dependency: zlib-devel(x86-64) for package: 1:openssl-devel-1.0.2k-16.152.amzn1.x86_64
--> Processing Dependency: krb5-devel(x86-64) for package: 1:openssl-devel-1.0.2k-16.152.amzn1.x86_64
--> Running transaction check
---> Package gcc48.x86_64 0:4.8.5-28.142.amzn1 will be installed
--> Processing Dependency: libgcc48(x86-64) = 4.8.5 for package: gcc48-4.8.5-28.142.amzn1.x86_64
--> Processing Dependency: cpp48(x86-64) = 4.8.5-28.142.amzn1 for package: gcc48-4.8.5-28.142.amzn1.x86_64
--> Processing Dependency: libgomp(x86-64) >= 4.8.5-28.142.amzn1 for package: gcc48-4.8.5-28.142.amzn1.x86_64
--> Processing Dependency: glibc-devel(x86-64) >= 2.2.90-12 for package: gcc48-4.8.5-28.142.amzn1.x86_64
--> Processing Dependency: binutils >= 2.20.51.0.2-12 for package: gcc48-4.8.5-28.142.amzn1.x86_64
--> Processing Dependency: libmpfr.so.4()(64bit) for package: gcc48-4.8.5-28.142.amzn1.x86_64
--> Processing Dependency: libmpc.so.3()(64bit) for package: gcc48-4.8.5-28.142.amzn1.x86_64
--> Processing Dependency: libgomp.so.1()(64bit) for package: gcc48-4.8.5-28.142.amzn1.x86_64
---> Package gcc48-c++.x86_64 0:4.8.5-28.142.amzn1 will be installed
---> Package krb5-devel.x86_64 0:1.15.1-46.48.amzn1 will be installed
--> Processing Dependency: libkadm5(x86-64) = 1.15.1-46.48.amzn1 for package: krb5-devel-1.15.1-46.48.amzn1.x86_64
--> Processing Dependency: libverto-devel for package: krb5-devel-1.15.1-46.48.amzn1.x86_64
--> Processing Dependency: libselinux-devel for package: krb5-devel-1.15.1-46.48.amzn1.x86_64
--> Processing Dependency: libcom_err-devel for package: krb5-devel-1.15.1-46.48.amzn1.x86_64
--> Processing Dependency: keyutils-libs-devel for package: krb5-devel-1.15.1-46.48.amzn1.x86_64
---> Package libstdc++48.x86_64 0:4.8.5-28.142.amzn1 will be installed
---> Package zlib-devel.x86_64 0:1.2.8-7.18.amzn1 will be installed
--> Running transaction check
---> Package binutils.x86_64 0:2.25.1-31.base.66.amzn1 will be installed
---> Package cpp48.x86_64 0:4.8.5-28.142.amzn1 will be installed
---> Package glibc-devel.x86_64 0:2.17-292.180.amzn1 will be installed
--> Processing Dependency: glibc-headers = 2.17-292.180.amzn1 for package: glibc-devel-2.17-292.180.amzn1.x86_64
--> Processing Dependency: glibc-headers for package: glibc-devel-2.17-292.180.amzn1.x86_64
---> Package keyutils-libs-devel.x86_64 0:1.5.8-3.12.amzn1 will be installed
---> Package libcom_err-devel.x86_64 0:1.43.5-2.43.amzn1 will be installed
---> Package libgcc48.x86_64 0:4.8.5-28.142.amzn1 will be installed
---> Package libgomp.x86_64 0:6.4.1-1.45.amzn1 will be installed
---> Package libkadm5.x86_64 0:1.15.1-46.48.amzn1 will be installed
---> Package libmpc.x86_64 0:1.0.1-3.3.amzn1 will be installed
---> Package libselinux-devel.x86_64 0:2.1.10-3.22.amzn1 will be installed
--> Processing Dependency: libsepol-devel >= 2.1.5-1 for package: libselinux-devel-2.1.10-3.22.amzn1.x86_64
--> Processing Dependency: pkgconfig(libsepol) for package: libselinux-devel-2.1.10-3.22.amzn1.x86_64
---> Package libverto-devel.x86_64 0:0.2.5-4.9.amzn1 will be installed
---> Package mpfr.x86_64 0:3.1.1-4.14.amzn1 will be installed
--> Running transaction check
---> Package glibc-headers.x86_64 0:2.17-292.180.amzn1 will be installed
--> Processing Dependency: kernel-headers >= 2.2.1 for package: glibc-headers-2.17-292.180.amzn1.x86_64
--> Processing Dependency: kernel-headers for package: glibc-headers-2.17-292.180.amzn1.x86_64
---> Package libsepol-devel.x86_64 0:2.1.7-3.12.amzn1 will be installed
--> Running transaction check
---> Package kernel-headers.x86_64 0:4.14.203-116.332.amzn1 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

================================================================================
 Package               Arch     Version                    Repository      Size
================================================================================
Installing:
 gcc                   noarch   4.8.5-1.22.amzn1           amzn-main      4.1 k
 gcc-c++               noarch   4.8.5-1.22.amzn1           amzn-main      4.0 k
 openssl-devel         x86_64   1:1.0.2k-16.152.amzn1      amzn-updates   1.7 M
Installing for dependencies:
 binutils              x86_64   2.25.1-31.base.66.amzn1    amzn-main      7.2 M
 cpp48                 x86_64   4.8.5-28.142.amzn1         amzn-updates   6.7 M
 gcc48                 x86_64   4.8.5-28.142.amzn1         amzn-updates    18 M
 gcc48-c++             x86_64   4.8.5-28.142.amzn1         amzn-updates   9.8 M
 glibc-devel           x86_64   2.17-292.180.amzn1         amzn-updates   1.2 M
 glibc-headers         x86_64   2.17-292.180.amzn1         amzn-updates   763 k
 kernel-headers        x86_64   4.14.203-116.332.amzn1     amzn-updates   1.3 M
 keyutils-libs-devel   x86_64   1.5.8-3.12.amzn1           amzn-main       37 k
 krb5-devel            x86_64   1.15.1-46.48.amzn1         amzn-updates   293 k
 libcom_err-devel      x86_64   1.43.5-2.43.amzn1          amzn-updates    36 k
 libgcc48              x86_64   4.8.5-28.142.amzn1         amzn-updates   155 k
 libgomp               x86_64   6.4.1-1.45.amzn1           amzn-main      204 k
 libkadm5              x86_64   1.15.1-46.48.amzn1         amzn-updates   203 k
 libmpc                x86_64   1.0.1-3.3.amzn1            amzn-main       53 k
 libselinux-devel      x86_64   2.1.10-3.22.amzn1          amzn-main      157 k
 libsepol-devel        x86_64   2.1.7-3.12.amzn1           amzn-main       70 k
 libstdc++48           x86_64   4.8.5-28.142.amzn1         amzn-updates   408 k
 libverto-devel        x86_64   0.2.5-4.9.amzn1            amzn-main       11 k
 mpfr                  x86_64   3.1.1-4.14.amzn1           amzn-main      237 k
 zlib-devel            x86_64   1.2.8-7.18.amzn1           amzn-main       53 k

Transaction Summary
================================================================================
Install  3 Packages (+20 Dependent packages)

Total download size: 48 M
Installed size: 108 M
Downloading packages:
--------------------------------------------------------------------------------
Total                                              3.0 MB/s |  48 MB  00:16     
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Installing : mpfr-3.1.1-4.14.amzn1.x86_64                                1/23 
  Installing : libmpc-1.0.1-3.3.amzn1.x86_64                               2/23 
  Installing : libgcc48-4.8.5-28.142.amzn1.x86_64                          3/23 
  Installing : libstdc++48-4.8.5-28.142.amzn1.x86_64                       4/23 
  Installing : binutils-2.25.1-31.base.66.amzn1.x86_64                     5/23 
  Installing : cpp48-4.8.5-28.142.amzn1.x86_64                             6/23 
  Installing : libcom_err-devel-1.43.5-2.43.amzn1.x86_64                   7/23 
  Installing : libverto-devel-0.2.5-4.9.amzn1.x86_64                       8/23 
  Installing : libsepol-devel-2.1.7-3.12.amzn1.x86_64                      9/23 
  Installing : libselinux-devel-2.1.10-3.22.amzn1.x86_64                  10/23 
  Installing : libgomp-6.4.1-1.45.amzn1.x86_64                            11/23 
  Installing : kernel-headers-4.14.203-116.332.amzn1.x86_64               12/23 
  Installing : glibc-headers-2.17-292.180.amzn1.x86_64                    13/23 
  Installing : glibc-devel-2.17-292.180.amzn1.x86_64                      14/23 
  Installing : gcc48-4.8.5-28.142.amzn1.x86_64                            15/23 
  Installing : gcc-4.8.5-1.22.amzn1.noarch                                16/23 
  Installing : gcc48-c++-4.8.5-28.142.amzn1.x86_64                        17/23 
  Installing : libkadm5-1.15.1-46.48.amzn1.x86_64                         18/23 
  Installing : zlib-devel-1.2.8-7.18.amzn1.x86_64                         19/23 
  Installing : keyutils-libs-devel-1.5.8-3.12.amzn1.x86_64                20/23 
  Installing : krb5-devel-1.15.1-46.48.amzn1.x86_64                       21/23 
  Installing : 1:openssl-devel-1.0.2k-16.152.amzn1.x86_64                 22/23 
  Installing : gcc-c++-4.8.5-1.22.amzn1.noarch                            23/23 
  Verifying  : gcc-4.8.5-1.22.amzn1.noarch                                 1/23 
  Verifying  : libstdc++48-4.8.5-28.142.amzn1.x86_64                       2/23 
  Verifying  : gcc-c++-4.8.5-1.22.amzn1.noarch                             3/23 
  Verifying  : glibc-devel-2.17-292.180.amzn1.x86_64                       4/23 
  Verifying  : mpfr-3.1.1-4.14.amzn1.x86_64                                5/23 
  Verifying  : libselinux-devel-2.1.10-3.22.amzn1.x86_64                   6/23 
  Verifying  : gcc48-4.8.5-28.142.amzn1.x86_64                             7/23 
  Verifying  : keyutils-libs-devel-1.5.8-3.12.amzn1.x86_64                 8/23 
  Verifying  : zlib-devel-1.2.8-7.18.amzn1.x86_64                          9/23 
  Verifying  : krb5-devel-1.15.1-46.48.amzn1.x86_64                       10/23 
  Verifying  : cpp48-4.8.5-28.142.amzn1.x86_64                            11/23 
  Verifying  : glibc-headers-2.17-292.180.amzn1.x86_64                    12/23 
  Verifying  : gcc48-c++-4.8.5-28.142.amzn1.x86_64                        13/23 
  Verifying  : libkadm5-1.15.1-46.48.amzn1.x86_64                         14/23 
  Verifying  : kernel-headers-4.14.203-116.332.amzn1.x86_64               15/23 
  Verifying  : libmpc-1.0.1-3.3.amzn1.x86_64                              16/23 
  Verifying  : libgomp-6.4.1-1.45.amzn1.x86_64                            17/23 
  Verifying  : 1:openssl-devel-1.0.2k-16.152.amzn1.x86_64                 18/23 
  Verifying  : libsepol-devel-2.1.7-3.12.amzn1.x86_64                     19/23 
  Verifying  : libverto-devel-0.2.5-4.9.amzn1.x86_64                      20/23 
  Verifying  : libcom_err-devel-1.43.5-2.43.amzn1.x86_64                  21/23 
  Verifying  : binutils-2.25.1-31.base.66.amzn1.x86_64                    22/23 
  Verifying  : libgcc48-4.8.5-28.142.amzn1.x86_64                         23/23 

Installed:
  gcc.noarch 0:4.8.5-1.22.amzn1               gcc-c++.noarch 0:4.8.5-1.22.amzn1 
  openssl-devel.x86_64 1:1.0.2k-16.152.amzn1 

Dependency Installed:
  binutils.x86_64 0:2.25.1-31.base.66.amzn1                                     
  cpp48.x86_64 0:4.8.5-28.142.amzn1                                             
  gcc48.x86_64 0:4.8.5-28.142.amzn1                                             
  gcc48-c++.x86_64 0:4.8.5-28.142.amzn1                                         
  glibc-devel.x86_64 0:2.17-292.180.amzn1                                       
  glibc-headers.x86_64 0:2.17-292.180.amzn1                                     
  kernel-headers.x86_64 0:4.14.203-116.332.amzn1                                
  keyutils-libs-devel.x86_64 0:1.5.8-3.12.amzn1                                 
  krb5-devel.x86_64 0:1.15.1-46.48.amzn1                                        
  libcom_err-devel.x86_64 0:1.43.5-2.43.amzn1                                   
  libgcc48.x86_64 0:4.8.5-28.142.amzn1                                          
  libgomp.x86_64 0:6.4.1-1.45.amzn1                                             
  libkadm5.x86_64 0:1.15.1-46.48.amzn1                                          
  libmpc.x86_64 0:1.0.1-3.3.amzn1                                               
  libselinux-devel.x86_64 0:2.1.10-3.22.amzn1                                   
  libsepol-devel.x86_64 0:2.1.7-3.12.amzn1                                      
  libstdc++48.x86_64 0:4.8.5-28.142.amzn1                                       
  libverto-devel.x86_64 0:0.2.5-4.9.amzn1                                       
  mpfr.x86_64 0:3.1.1-4.14.amzn1                                                
  zlib-devel.x86_64 0:1.2.8-7.18.amzn1                                          

Complete!
info: downloading installer
info: profile set to 'minimal'
info: default host triple is x86_64-unknown-linux-gnu
info: syncing channel updates for '1.49.0-x86_64-unknown-linux-gnu'
info: latest update on 2020-12-31, rust version 1.49.0 (e1884a8e3 2020-12-29)
info: downloading component 'cargo'
info: downloading component 'rust-std'
info: downloading component 'rustc'
info: installing component 'cargo'
info: using up to 500.0 MiB of RAM to unpack components
info: installing component 'rust-std'
info: installing component 'rustc'
info: default toolchain set to '1.49.0-x86_64-unknown-linux-gnu'

  1.49.0-x86_64-unknown-linux-gnu installed - rustc 1.49.0 (e1884a8e3 2020-12-29)


Rust is installed now. Great!

To get started you need Cargo's bin directory (/usr/local/cargo/bin) in your 
PATH
environment variable.

To configure your current shell, run:
source /usr/local/cargo/env
rustup 1.23.1 (3df2264a9 2020-11-30)info: This is the version for the rustup toolchain manager, not the rustc compiler.

info: The currently active `rustc` version is `rustc 1.49.0 (e1884a8e3 2020-12-29)`
cargo 1.49.0 (d00d64df9 2020-12-05)
rustc 1.49.0 (e1884a8e3 2020-12-29)
Removing intermediate container 36d0156a66a6
 ---> fa0acf635ed4
Step 5/5 : WORKDIR /volume
 ---> Running in bcb02d7a6739
Removing intermediate container bcb02d7a6739
 ---> 563c864b4262
Successfully built 563c864b4262
Successfully tagged rust:1.49.0-amazonlinux2018.03.0.20201209.1
docker tag rust:1.49.0-amazonlinux2018.03.0.20201209.1 ewbankkit/rust-amazonlinux:1.49.0-2018.03.0.20201209.1
$ make push_al
docker build --file Dockerfile.al --tag rust:1.49.0-amazonlinux2018.03.0.20201209.1 .
Sending build context to Docker daemon  141.3kB
Step 1/5 : FROM amazonlinux:2018.03.0.20201209.1
 ---> ff3a6f913fa9
Step 2/5 : LABEL maintainer="Kit Ewbank <Kit_Ewbank@hotmail.com>"
 ---> Using cache
 ---> 12a1c6f743cf
Step 3/5 : ENV RUSTUP_HOME=/usr/local/rustup     CARGO_HOME=/usr/local/cargo     PATH=/usr/local/cargo/bin:$PATH     RUST_VERSION=1.49.0
 ---> Using cache
 ---> 2428671b2289
Step 4/5 : RUN yum install -y gcc gcc-c++ openssl-devel;     curl https://sh.rustup.rs -sSf | sh -s -- --no-modify-path --profile minimal --default-toolchain $RUST_VERSION -y;     chmod -R a+w $RUSTUP_HOME $CARGO_HOME;     rustup --version;     cargo --version;     rustc --version;
 ---> Using cache
 ---> fa0acf635ed4
Step 5/5 : WORKDIR /volume
 ---> Using cache
 ---> 563c864b4262
Successfully built 563c864b4262
Successfully tagged rust:1.49.0-amazonlinux2018.03.0.20201209.1
docker tag rust:1.49.0-amazonlinux2018.03.0.20201209.1 ewbankkit/rust-amazonlinux:1.49.0-2018.03.0.20201209.1
docker push ewbankkit/rust-amazonlinux:1.49.0-2018.03.0.20201209.1
The push refers to repository [docker.io/ewbankkit/rust-amazonlinux]
e4b12e02b588: Pushed 
f58cfa3b88d2: Pushed 
087719389ee1: Mounted from library/amazonlinux 
1.49.0-2018.03.0.20201209.1: digest: sha256:691f024304c5c88b4d6cfe18219481bb8026add67ef32cb667d22d6f3e50c249 size: 949
$ make image_al2
docker build --file Dockerfile.al2 --tag rust:1.49.0-amazonlinux2.0.20201218.1 .
Sending build context to Docker daemon    150kB
Step 1/5 : FROM amazonlinux:2.0.20201218.1
2.0.20201218.1: Pulling from library/amazonlinux
4232b9ee675b: Pull complete 
Digest: sha256:420a6503505c73ea05e1254acd4d1a5e73305dab8ec3fa70833e112cc6980624
Status: Downloaded newer image for amazonlinux:2.0.20201218.1
 ---> 9917dfe117ca
Step 2/5 : LABEL maintainer="Kit Ewbank <Kit_Ewbank@hotmail.com>"
 ---> Running in 86ebc01d06dc
Removing intermediate container 86ebc01d06dc
 ---> b908d72b0f78
Step 3/5 : ENV RUSTUP_HOME=/usr/local/rustup     CARGO_HOME=/usr/local/cargo     PATH=/usr/local/cargo/bin:$PATH     RUST_VERSION=1.49.0
 ---> Running in 3dd60042c001
Removing intermediate container 3dd60042c001
 ---> a5ef04eea916
Step 4/5 : RUN yum install -y gcc gcc-c++ openssl-devel;     curl https://sh.rustup.rs -sSf | sh -s -- --no-modify-path --profile minimal --default-toolchain $RUST_VERSION -y;     chmod -R a+w $RUSTUP_HOME $CARGO_HOME;     rustup --version;     cargo --version;     rustc --version;
 ---> Running in 67f44b15f892
Loaded plugins: ovl, priorities
Resolving Dependencies
--> Running transaction check
---> Package gcc.x86_64 0:7.3.1-12.amzn2 will be installed
--> Processing Dependency: libgomp = 7.3.1-12.amzn2 for package: gcc-7.3.1-12.amzn2.x86_64
--> Processing Dependency: cpp = 7.3.1-12.amzn2 for package: gcc-7.3.1-12.amzn2.x86_64
--> Processing Dependency: libsanitizer >= 7.3.1-12.amzn2 for package: gcc-7.3.1-12.amzn2.x86_64
--> Processing Dependency: libquadmath >= 7.3.1-12.amzn2 for package: gcc-7.3.1-12.amzn2.x86_64
--> Processing Dependency: libmpx >= 7.3.1-12.amzn2 for package: gcc-7.3.1-12.amzn2.x86_64
--> Processing Dependency: libitm >= 7.3.1-12.amzn2 for package: gcc-7.3.1-12.amzn2.x86_64
--> Processing Dependency: libcilkrts >= 7.3.1-12.amzn2 for package: gcc-7.3.1-12.amzn2.x86_64
--> Processing Dependency: libatomic >= 7.3.1-12.amzn2 for package: gcc-7.3.1-12.amzn2.x86_64
--> Processing Dependency: glibc-devel >= 2.2.90-12 for package: gcc-7.3.1-12.amzn2.x86_64
--> Processing Dependency: binutils >= 2.24 for package: gcc-7.3.1-12.amzn2.x86_64
--> Processing Dependency: libmpfr.so.4()(64bit) for package: gcc-7.3.1-12.amzn2.x86_64
--> Processing Dependency: libmpc.so.3()(64bit) for package: gcc-7.3.1-12.amzn2.x86_64
--> Processing Dependency: libgomp.so.1()(64bit) for package: gcc-7.3.1-12.amzn2.x86_64
---> Package gcc-c++.x86_64 0:7.3.1-12.amzn2 will be installed
---> Package openssl-devel.x86_64 1:1.0.2k-19.amzn2.0.4 will be installed
--> Processing Dependency: zlib-devel(x86-64) for package: 1:openssl-devel-1.0.2k-19.amzn2.0.4.x86_64
--> Processing Dependency: pkgconfig for package: 1:openssl-devel-1.0.2k-19.amzn2.0.4.x86_64
--> Processing Dependency: krb5-devel(x86-64) for package: 1:openssl-devel-1.0.2k-19.amzn2.0.4.x86_64
--> Processing Dependency: /usr/bin/pkg-config for package: 1:openssl-devel-1.0.2k-19.amzn2.0.4.x86_64
--> Running transaction check
---> Package binutils.x86_64 0:2.29.1-30.amzn2 will be installed
---> Package cpp.x86_64 0:7.3.1-12.amzn2 will be installed
---> Package glibc-devel.x86_64 0:2.26-39.amzn2 will be installed
--> Processing Dependency: glibc-headers = 2.26-39.amzn2 for package: glibc-devel-2.26-39.amzn2.x86_64
--> Processing Dependency: glibc-headers for package: glibc-devel-2.26-39.amzn2.x86_64
---> Package krb5-devel.x86_64 0:1.15.1-37.amzn2.2.2 will be installed
--> Processing Dependency: libkadm5(x86-64) = 1.15.1-37.amzn2.2.2 for package: krb5-devel-1.15.1-37.amzn2.2.2.x86_64
--> Processing Dependency: libverto-devel for package: krb5-devel-1.15.1-37.amzn2.2.2.x86_64
--> Processing Dependency: libselinux-devel for package: krb5-devel-1.15.1-37.amzn2.2.2.x86_64
--> Processing Dependency: libcom_err-devel for package: krb5-devel-1.15.1-37.amzn2.2.2.x86_64
--> Processing Dependency: keyutils-libs-devel for package: krb5-devel-1.15.1-37.amzn2.2.2.x86_64
---> Package libatomic.x86_64 0:7.3.1-12.amzn2 will be installed
---> Package libcilkrts.x86_64 0:7.3.1-12.amzn2 will be installed
---> Package libgomp.x86_64 0:7.3.1-12.amzn2 will be installed
---> Package libitm.x86_64 0:7.3.1-12.amzn2 will be installed
---> Package libmpc.x86_64 0:1.0.1-3.amzn2.0.2 will be installed
---> Package libmpx.x86_64 0:7.3.1-12.amzn2 will be installed
---> Package libquadmath.x86_64 0:7.3.1-12.amzn2 will be installed
---> Package libsanitizer.x86_64 0:7.3.1-12.amzn2 will be installed
---> Package mpfr.x86_64 0:3.1.1-4.amzn2.0.2 will be installed
---> Package pkgconfig.x86_64 1:0.27.1-4.amzn2.0.2 will be installed
---> Package zlib-devel.x86_64 0:1.2.7-18.amzn2 will be installed
--> Running transaction check
---> Package glibc-headers.x86_64 0:2.26-39.amzn2 will be installed
--> Processing Dependency: kernel-headers >= 2.2.1 for package: glibc-headers-2.26-39.amzn2.x86_64
--> Processing Dependency: kernel-headers for package: glibc-headers-2.26-39.amzn2.x86_64
---> Package keyutils-libs-devel.x86_64 0:1.5.8-3.amzn2.0.2 will be installed
---> Package libcom_err-devel.x86_64 0:1.42.9-19.amzn2 will be installed
---> Package libkadm5.x86_64 0:1.15.1-37.amzn2.2.2 will be installed
---> Package libselinux-devel.x86_64 0:2.5-12.amzn2.0.2 will be installed
--> Processing Dependency: libsepol-devel(x86-64) >= 2.5-6 for package: libselinux-devel-2.5-12.amzn2.0.2.x86_64
--> Processing Dependency: pkgconfig(libsepol) for package: libselinux-devel-2.5-12.amzn2.0.2.x86_64
--> Processing Dependency: pkgconfig(libpcre) for package: libselinux-devel-2.5-12.amzn2.0.2.x86_64
---> Package libverto-devel.x86_64 0:0.2.5-4.amzn2.0.2 will be installed
--> Running transaction check
---> Package kernel-headers.x86_64 0:4.14.209-160.339.amzn2 will be installed
---> Package libsepol-devel.x86_64 0:2.5-8.1.amzn2.0.2 will be installed
---> Package pcre-devel.x86_64 0:8.32-17.amzn2.0.2 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

================================================================================
 Package                Arch      Version                   Repository     Size
================================================================================
Installing:
 gcc                    x86_64    7.3.1-12.amzn2            amzn2-core     22 M
 gcc-c++                x86_64    7.3.1-12.amzn2            amzn2-core     13 M
 openssl-devel          x86_64    1:1.0.2k-19.amzn2.0.4     amzn2-core    1.5 M
Installing for dependencies:
 binutils               x86_64    2.29.1-30.amzn2           amzn2-core    5.8 M
 cpp                    x86_64    7.3.1-12.amzn2            amzn2-core    9.2 M
 glibc-devel            x86_64    2.26-39.amzn2             amzn2-core    990 k
 glibc-headers          x86_64    2.26-39.amzn2             amzn2-core    511 k
 kernel-headers         x86_64    4.14.209-160.339.amzn2    amzn2-core    1.1 M
 keyutils-libs-devel    x86_64    1.5.8-3.amzn2.0.2         amzn2-core     37 k
 krb5-devel             x86_64    1.15.1-37.amzn2.2.2       amzn2-core    272 k
 libatomic              x86_64    7.3.1-12.amzn2            amzn2-core     46 k
 libcilkrts             x86_64    7.3.1-12.amzn2            amzn2-core     85 k
 libcom_err-devel       x86_64    1.42.9-19.amzn2           amzn2-core     32 k
 libgomp                x86_64    7.3.1-12.amzn2            amzn2-core    204 k
 libitm                 x86_64    7.3.1-12.amzn2            amzn2-core     84 k
 libkadm5               x86_64    1.15.1-37.amzn2.2.2       amzn2-core    179 k
 libmpc                 x86_64    1.0.1-3.amzn2.0.2         amzn2-core     52 k
 libmpx                 x86_64    7.3.1-12.amzn2            amzn2-core     51 k
 libquadmath            x86_64    7.3.1-12.amzn2            amzn2-core    189 k
 libsanitizer           x86_64    7.3.1-12.amzn2            amzn2-core    641 k
 libselinux-devel       x86_64    2.5-12.amzn2.0.2          amzn2-core    187 k
 libsepol-devel         x86_64    2.5-8.1.amzn2.0.2         amzn2-core     77 k
 libverto-devel         x86_64    0.2.5-4.amzn2.0.2         amzn2-core     12 k
 mpfr                   x86_64    3.1.1-4.amzn2.0.2         amzn2-core    208 k
 pcre-devel             x86_64    8.32-17.amzn2.0.2         amzn2-core    480 k
 pkgconfig              x86_64    1:0.27.1-4.amzn2.0.2      amzn2-core     54 k
 zlib-devel             x86_64    1.2.7-18.amzn2            amzn2-core     50 k

Transaction Summary
================================================================================
Install  3 Packages (+24 Dependent packages)

Total download size: 57 M
Installed size: 165 M
Downloading packages:
--------------------------------------------------------------------------------
Total                                              9.6 MB/s |  57 MB  00:05     
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Installing : 1:pkgconfig-0.27.1-4.amzn2.0.2.x86_64                       1/27 
  Installing : mpfr-3.1.1-4.amzn2.0.2.x86_64                               2/27 
  Installing : libmpc-1.0.1-3.amzn2.0.2.x86_64                             3/27 
  Installing : cpp-7.3.1-12.amzn2.x86_64                                   4/27 
  Installing : libcom_err-devel-1.42.9-19.amzn2.x86_64                     5/27 
  Installing : libsepol-devel-2.5-8.1.amzn2.0.2.x86_64                     6/27 
  Installing : libverto-devel-0.2.5-4.amzn2.0.2.x86_64                     7/27 
  Installing : zlib-devel-1.2.7-18.amzn2.x86_64                            8/27 
  Installing : pcre-devel-8.32-17.amzn2.0.2.x86_64                         9/27 
  Installing : libselinux-devel-2.5-12.amzn2.0.2.x86_64                   10/27 
  Installing : libgomp-7.3.1-12.amzn2.x86_64                              11/27 
  Installing : binutils-2.29.1-30.amzn2.x86_64                            12/27 
  Installing : libmpx-7.3.1-12.amzn2.x86_64                               13/27 
  Installing : keyutils-libs-devel-1.5.8-3.amzn2.0.2.x86_64               14/27 
  Installing : libatomic-7.3.1-12.amzn2.x86_64                            15/27 
  Installing : kernel-headers-4.14.209-160.339.amzn2.x86_64               16/27 
  Installing : glibc-headers-2.26-39.amzn2.x86_64                         17/27 
  Installing : glibc-devel-2.26-39.amzn2.x86_64                           18/27 
  Installing : libsanitizer-7.3.1-12.amzn2.x86_64                         19/27 
  Installing : libkadm5-1.15.1-37.amzn2.2.2.x86_64                        20/27 
  Installing : krb5-devel-1.15.1-37.amzn2.2.2.x86_64                      21/27 
  Installing : libquadmath-7.3.1-12.amzn2.x86_64                          22/27 
  Installing : libcilkrts-7.3.1-12.amzn2.x86_64                           23/27 
  Installing : libitm-7.3.1-12.amzn2.x86_64                               24/27 
  Installing : gcc-7.3.1-12.amzn2.x86_64                                  25/27 
  Installing : gcc-c++-7.3.1-12.amzn2.x86_64                              26/27 
  Installing : 1:openssl-devel-1.0.2k-19.amzn2.0.4.x86_64                 27/27 
  Verifying  : libitm-7.3.1-12.amzn2.x86_64                                1/27 
  Verifying  : 1:openssl-devel-1.0.2k-19.amzn2.0.4.x86_64                  2/27 
  Verifying  : libcilkrts-7.3.1-12.amzn2.x86_64                            3/27 
  Verifying  : libcom_err-devel-1.42.9-19.amzn2.x86_64                     4/27 
  Verifying  : cpp-7.3.1-12.amzn2.x86_64                                   5/27 
  Verifying  : libmpc-1.0.1-3.amzn2.0.2.x86_64                             6/27 
  Verifying  : glibc-headers-2.26-39.amzn2.x86_64                          7/27 
  Verifying  : libquadmath-7.3.1-12.amzn2.x86_64                           8/27 
  Verifying  : libkadm5-1.15.1-37.amzn2.2.2.x86_64                         9/27 
  Verifying  : libsepol-devel-2.5-8.1.amzn2.0.2.x86_64                    10/27 
  Verifying  : libverto-devel-0.2.5-4.amzn2.0.2.x86_64                    11/27 
  Verifying  : glibc-devel-2.26-39.amzn2.x86_64                           12/27 
  Verifying  : zlib-devel-1.2.7-18.amzn2.x86_64                           13/27 
  Verifying  : mpfr-3.1.1-4.amzn2.0.2.x86_64                              14/27 
  Verifying  : libsanitizer-7.3.1-12.amzn2.x86_64                         15/27 
  Verifying  : libselinux-devel-2.5-12.amzn2.0.2.x86_64                   16/27 
  Verifying  : kernel-headers-4.14.209-160.339.amzn2.x86_64               17/27 
  Verifying  : gcc-c++-7.3.1-12.amzn2.x86_64                              18/27 
  Verifying  : 1:pkgconfig-0.27.1-4.amzn2.0.2.x86_64                      19/27 
  Verifying  : krb5-devel-1.15.1-37.amzn2.2.2.x86_64                      20/27 
  Verifying  : gcc-7.3.1-12.amzn2.x86_64                                  21/27 
  Verifying  : libatomic-7.3.1-12.amzn2.x86_64                            22/27 
  Verifying  : pcre-devel-8.32-17.amzn2.0.2.x86_64                        23/27 
  Verifying  : keyutils-libs-devel-1.5.8-3.amzn2.0.2.x86_64               24/27 
  Verifying  : libmpx-7.3.1-12.amzn2.x86_64                               25/27 
  Verifying  : binutils-2.29.1-30.amzn2.x86_64                            26/27 
  Verifying  : libgomp-7.3.1-12.amzn2.x86_64                              27/27 

Installed:
  gcc.x86_64 0:7.3.1-12.amzn2                  gcc-c++.x86_64 0:7.3.1-12.amzn2  
  openssl-devel.x86_64 1:1.0.2k-19.amzn2.0.4  

Dependency Installed:
  binutils.x86_64 0:2.29.1-30.amzn2                                             
  cpp.x86_64 0:7.3.1-12.amzn2                                                   
  glibc-devel.x86_64 0:2.26-39.amzn2                                            
  glibc-headers.x86_64 0:2.26-39.amzn2                                          
  kernel-headers.x86_64 0:4.14.209-160.339.amzn2                                
  keyutils-libs-devel.x86_64 0:1.5.8-3.amzn2.0.2                                
  krb5-devel.x86_64 0:1.15.1-37.amzn2.2.2                                       
  libatomic.x86_64 0:7.3.1-12.amzn2                                             
  libcilkrts.x86_64 0:7.3.1-12.amzn2                                            
  libcom_err-devel.x86_64 0:1.42.9-19.amzn2                                     
  libgomp.x86_64 0:7.3.1-12.amzn2                                               
  libitm.x86_64 0:7.3.1-12.amzn2                                                
  libkadm5.x86_64 0:1.15.1-37.amzn2.2.2                                         
  libmpc.x86_64 0:1.0.1-3.amzn2.0.2                                             
  libmpx.x86_64 0:7.3.1-12.amzn2                                                
  libquadmath.x86_64 0:7.3.1-12.amzn2                                           
  libsanitizer.x86_64 0:7.3.1-12.amzn2                                          
  libselinux-devel.x86_64 0:2.5-12.amzn2.0.2                                    
  libsepol-devel.x86_64 0:2.5-8.1.amzn2.0.2                                     
  libverto-devel.x86_64 0:0.2.5-4.amzn2.0.2                                     
  mpfr.x86_64 0:3.1.1-4.amzn2.0.2                                               
  pcre-devel.x86_64 0:8.32-17.amzn2.0.2                                         
  pkgconfig.x86_64 1:0.27.1-4.amzn2.0.2                                         
  zlib-devel.x86_64 0:1.2.7-18.amzn2                                            

Complete!
info: downloading installer
info: profile set to 'minimal'
info: default host triple is x86_64-unknown-linux-gnu
info: syncing channel updates for '1.49.0-x86_64-unknown-linux-gnu'
info: latest update on 2020-12-31, rust version 1.49.0 (e1884a8e3 2020-12-29)
info: downloading component 'cargo'
info: downloading component 'rust-std'
info: downloading component 'rustc'
info: installing component 'cargo'
info: using up to 500.0 MiB of RAM to unpack components
info: installing component 'rust-std'
info: installing component 'rustc'
info: 
default toolchain set to '1.49.0-x86_64-unknown-linux-gnu'
  1.49.0-x86_64-unknown-linux-gnu installed - rustc 1.49.0 (e1884a8e3 2020-12-29)


Rust is installed now. Great!

To get started you need Cargo's bin directory (/usr/local/cargo/bin) in your 
PATH
environment variable.

To configure your current shell, run:
source /usr/local/cargo/env
rustup 1.23.1 (3df2264a9 2020-11-30)info: This is the version for the rustup toolchain manager, not the rustc compiler.

info: The currently active `rustc` version is `rustc 1.49.0 (e1884a8e3 2020-12-29)`
cargo 1.49.0 (d00d64df9 2020-12-05)
rustc 1.49.0 (e1884a8e3 2020-12-29)
Removing intermediate container 67f44b15f892
 ---> 7d58d026942c
Step 5/5 : WORKDIR /volume
 ---> Running in c57b10e76a22
Removing intermediate container c57b10e76a22
 ---> a0f80e3fcd42
Successfully built a0f80e3fcd42
Successfully tagged rust:1.49.0-amazonlinux2.0.20201218.1
docker tag rust:1.49.0-amazonlinux2.0.20201218.1 ewbankkit/rust-amazonlinux:1.49.0-2.0.20201218.1
$ make push_al2
docker build --file Dockerfile.al2 --tag rust:1.49.0-amazonlinux2.0.20201218.1 .
Sending build context to Docker daemon    150kB
Step 1/5 : FROM amazonlinux:2.0.20201218.1
 ---> 9917dfe117ca
Step 2/5 : LABEL maintainer="Kit Ewbank <Kit_Ewbank@hotmail.com>"
 ---> Using cache
 ---> b908d72b0f78
Step 3/5 : ENV RUSTUP_HOME=/usr/local/rustup     CARGO_HOME=/usr/local/cargo     PATH=/usr/local/cargo/bin:$PATH     RUST_VERSION=1.49.0
 ---> Using cache
 ---> a5ef04eea916
Step 4/5 : RUN yum install -y gcc gcc-c++ openssl-devel;     curl https://sh.rustup.rs -sSf | sh -s -- --no-modify-path --profile minimal --default-toolchain $RUST_VERSION -y;     chmod -R a+w $RUSTUP_HOME $CARGO_HOME;     rustup --version;     cargo --version;     rustc --version;
 ---> Using cache
 ---> 7d58d026942c
Step 5/5 : WORKDIR /volume
 ---> Using cache
 ---> a0f80e3fcd42
Successfully built a0f80e3fcd42
Successfully tagged rust:1.49.0-amazonlinux2.0.20201218.1
docker tag rust:1.49.0-amazonlinux2.0.20201218.1 ewbankkit/rust-amazonlinux:1.49.0-2.0.20201218.1
docker push ewbankkit/rust-amazonlinux:1.49.0-2.0.20201218.1
The push refers to repository [docker.io/ewbankkit/rust-amazonlinux]
6a025e3dcb01: Pushed 
04fa186377ce: Pushed 
cee8d35c645b: Mounted from library/amazonlinux 
1.49.0-2.0.20201218.1: digest: sha256:eb6ac2a76232be4458e7428de81f6df55d96b9f2bc27db93e4a0b7d5d18f6d70 size: 949
```